### PR TITLE
feat(pets): add local pet creation workflow

### DIFF
--- a/Sources/App/CreatePetView.swift
+++ b/Sources/App/CreatePetView.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct CreatePetView: View {
+    var onCreate: (String) -> Void
+    var onCancel: () -> Void
+
+    @State private var displayName = ""
+    @State private var description = ""
+    @State private var spritesheetURL: URL?
+    @State private var errorText: String?
+
+    private var canCreate: Bool {
+        !displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && spritesheetURL != nil
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Create pet").font(.headline)
+                Spacer()
+                Button("Cancel") { onCancel() }
+            }
+            .padding(12)
+            Divider()
+
+            Form {
+                Section("Pet info") {
+                    TextField("Name", text: $displayName)
+                    TextField("Description", text: $description)
+                }
+
+                Section {
+                    HStack {
+                        Text(spritesheetURL?.lastPathComponent ?? "No image selected")
+                            .foregroundStyle(spritesheetURL == nil ? .secondary : .primary)
+                            .lineLimit(1)
+                        Spacer()
+                        Button("Choose image…") { chooseSpritesheet() }
+                    }
+                } header: {
+                    Text("Spritesheet")
+                } footer: {
+                    Text("Use the same 8×9 transparent spritesheet format as downloaded pets.")
+                }
+
+                if let errorText {
+                    Section {
+                        Text(errorText)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+            .formStyle(.grouped)
+
+            Divider()
+            HStack {
+                Spacer()
+                Button("Create") { create() }
+                    .buttonStyle(.borderedProminent)
+                    .tint(Color.systemAccent)
+                    .disabled(!canCreate)
+                    .keyboardShortcut(.defaultAction)
+            }
+            .padding(12)
+        }
+        .frame(width: 480, height: 430)
+        .preferredColorScheme(.dark)
+        .noFocusRing()
+    }
+
+    private func chooseSpritesheet() {
+        let panel = NSOpenPanel()
+        panel.title = "Choose Spritesheet"
+        panel.prompt = "Choose"
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowsMultipleSelection = false
+        panel.allowedContentTypes = [.image]
+
+        if panel.runModal() == .OK {
+            spritesheetURL = panel.url
+            errorText = nil
+        }
+    }
+
+    private func create() {
+        guard let spritesheetURL else { return }
+        guard let id = PetInstaller.createLocalPack(
+            displayName: displayName,
+            description: description,
+            spritesheetURL: spritesheetURL
+        ) else {
+            errorText = "Could not create this pet. Check that the image is a valid spritesheet."
+            return
+        }
+        onCreate(id)
+    }
+}

--- a/Sources/App/OnboardingView.swift
+++ b/Sources/App/OnboardingView.swift
@@ -9,6 +9,7 @@ struct OnboardingView: View {
     var onFinish: () -> Void
 
     @State private var browsing = false
+    @State private var creating = false
 
     private var selectedPack: ImagePetPack? {
         pet.selectedPetID.flatMap { imagePets.pack(id: $0) }
@@ -32,12 +33,22 @@ struct OnboardingView: View {
             }
             .padding(EdgeInsets(top: 40, leading: 28, bottom: 28, trailing: 28))
         }
-        .frame(width: 560, height: 640)
+        .frame(width: 640, height: 640)
         .background(Theme.background)
         .preferredColorScheme(.dark)
         .noFocusRing()
         .onAppear { model.refresh() }
         .sheet(isPresented: $browsing) { BrowsePetsView(onClose: { browsing = false }) }
+        .sheet(isPresented: $creating) {
+            CreatePetView(
+                onCreate: { id in
+                    creating = false
+                    imagePets.reload()
+                    pet.selectedPetID = id
+                },
+                onCancel: { creating = false }
+            )
+        }
     }
 
     private var header: some View {
@@ -74,8 +85,13 @@ struct OnboardingView: View {
                     if let d = selectedPack?.description {
                         Text(d).font(.caption).foregroundStyle(.white.opacity(0.6)).lineLimit(3)
                     }
-                    Button { browsing = true } label: {
-                        Label("Browse pets", systemImage: "square.grid.2x2")
+                    HStack {
+                        Button { browsing = true } label: {
+                            Label("Browse pets", systemImage: "square.grid.2x2")
+                        }
+                        Button { creating = true } label: {
+                            Label("Create pet", systemImage: "square.and.pencil")
+                        }
                     }
                     .buttonStyle(.plain).foregroundStyle(Color.systemAccent)
                 }

--- a/Sources/App/PetInstaller.swift
+++ b/Sources/App/PetInstaller.swift
@@ -5,6 +5,12 @@ import AgentPetCore
 /// Shared by the Browse gallery and first-run onboarding.
 enum PetInstaller {
     private struct PackMeta: Decodable { let id: String?; let spritesheetPath: String }
+    private struct LocalPackManifest: Encodable {
+        let id: String
+        let displayName: String
+        let description: String?
+        let spritesheetPath: String
+    }
 
     /// Returns the installed pack's id (pet.json `id`), or nil on failure.
     @discardableResult
@@ -27,6 +33,85 @@ enum PetInstaller {
             return nil
         }
     }
+
+    /// Creates a new local pet pack from user-entered metadata and a
+    /// spritesheet image. Returns the installed pack's id on success.
+    @discardableResult
+    static func createLocalPack(displayName: String,
+                                description: String?,
+                                spritesheetURL: URL) -> String? {
+        let fm = FileManager.default
+        let cleanName = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let ext = spritesheetURL.pathExtension.isEmpty ? "png" : spritesheetURL.pathExtension
+        let sheetName = "spritesheet.\(ext.lowercased())"
+
+        do {
+            let petsDir = URL(fileURLWithPath: AgentPetPaths.baseDir).appendingPathComponent("pets")
+            try fm.createDirectory(at: petsDir, withIntermediateDirectories: true)
+            let id = uniquePetID(base: safeFolderName(cleanName), in: petsDir)
+            let staging = petsDir.appendingPathComponent(".create-\(UUID().uuidString)")
+            try fm.createDirectory(at: staging, withIntermediateDirectories: true)
+            var committed = false
+            defer {
+                if !committed {
+                    try? fm.removeItem(at: staging)
+                }
+            }
+
+            let manifest = LocalPackManifest(
+                id: id,
+                displayName: cleanName,
+                description: description?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty,
+                spritesheetPath: sheetName
+            )
+
+            let data = try JSONEncoder.petManifest.encode(manifest)
+            try data.write(to: staging.appendingPathComponent("pet.json"))
+            try fm.copyItem(at: spritesheetURL, to: staging.appendingPathComponent(sheetName))
+
+            guard SpriteSlicer.loadPack(directory: staging) != nil else {
+                return nil
+            }
+
+            let destination = petsDir.appendingPathComponent(id)
+            try fm.moveItem(at: staging, to: destination)
+            committed = true
+            return id
+        } catch {
+            return nil
+        }
+    }
+
+    private static func uniquePetID(base: String, in petsDir: URL) -> String {
+        let fm = FileManager.default
+        let seed = base.isEmpty ? UUID().uuidString : base
+        var candidate = seed
+        var index = 2
+        while fm.fileExists(atPath: petsDir.appendingPathComponent(candidate).path) {
+            candidate = "\(seed)-\(index)"
+            index += 1
+        }
+        return candidate
+    }
+
+    private static func safeFolderName(_ value: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+        let scalars = value.unicodeScalars.map { allowed.contains($0) ? Character($0) : "-" }
+        let name = String(scalars).trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+        return name.isEmpty ? UUID().uuidString : name
+    }
+}
+
+private extension JSONEncoder {
+    static var petManifest: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return encoder
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? { isEmpty ? nil : self }
 }
 
 /// Installs a starter pet on the very first launch so the app isn't empty.

--- a/Sources/App/SetupView.swift
+++ b/Sources/App/SetupView.swift
@@ -31,7 +31,7 @@ struct SetupView: View {
                 }
             }
         }
-        .frame(width: 560, height: 600)
+        .frame(width: 640, height: 600)
         .preferredColorScheme(.dark)
         .noFocusRing()
         .onAppear { model.refresh() }
@@ -356,6 +356,7 @@ private struct PetTab: View {
     @ObservedObject var model: SettingsModel
     let selectedPack: ImagePetPack?
     @State private var browsing = false
+    @State private var creating = false
     @State private var petQuery = ""
 
     private var filteredPacks: [ImagePetPack] {
@@ -398,8 +399,13 @@ private struct PetTab: View {
                                  if wasSelected { pet.selectedPetID = imagePets.packs.first?.id }
                              })
                 }
-                Button { browsing = true } label: {
-                    Label("Browse pets…", systemImage: "square.grid.2x2")
+                HStack {
+                    Button { browsing = true } label: {
+                        Label("Browse pets…", systemImage: "square.grid.2x2")
+                    }
+                    Button { creating = true } label: {
+                        Label("Create pet…", systemImage: "square.and.pencil")
+                    }
                 }
             }
 
@@ -424,6 +430,16 @@ private struct PetTab: View {
         .formStyle(.grouped)
         .sheet(isPresented: $browsing) {
             BrowsePetsView(onClose: { browsing = false })
+        }
+        .sheet(isPresented: $creating) {
+            CreatePetView(
+                onCreate: { id in
+                    creating = false
+                    imagePets.reload()
+                    pet.selectedPetID = id
+                },
+                onCancel: { creating = false }
+            )
         }
     }
 


### PR DESCRIPTION
  ## Summary
  - Add a local Create pet flow for user-entered pet metadata
  - Generate pet.json automatically from name, description, and spritesheet
  - Auto-generate unique pet IDs to avoid overwriting existing pets
  - Add Create pet entry points in Settings and onboarding
  - Widen Settings/onboarding windows to avoid button wrapping
  
<img width="752" height="744" alt="Screenshot 2026-06-04 at 14 26 45" src="https://github.com/user-attachments/assets/d2ed084c-95d4-4918-b7ae-d844cbabf5a3" />
<img width="752" height="744" alt="Screenshot 2026-06-04 at 14 26 56" src="https://github.com/user-attachments/assets/150fd317-0bf6-4355-a394-3704912d4c8f" />
<img width="752" height="744" alt="Screenshot 2026-06-04 at 14 27 40" src="https://github.com/user-attachments/assets/dece0771-85f4-43f1-ba3d-ab4e69122810" />
