### PR TITLE
fix: crash on launch from @MainActor UserNotifications completion handlers (SIGTRAP)

### DIFF
--- a/Sources/App/SettingsModel.swift
+++ b/Sources/App/SettingsModel.swift
@@ -1,6 +1,6 @@
 import AppKit
 import Foundation
-import UserNotifications
+@preconcurrency import UserNotifications
 import AgentPetCore
 
 /// Backs the onboarding/Settings window: notification permission status and
@@ -82,8 +82,9 @@ final class SettingsModel: ObservableObject {
 
     func enableNotifications() {
         guard NotificationManager.shared.isAvailable else { return }
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in
-            Task { @MainActor in self.refreshNotificationState() }
+        Task { @MainActor in
+            _ = try? await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound])
+            self.refreshNotificationState()
         }
     }
 
@@ -99,17 +100,15 @@ final class SettingsModel: ObservableObject {
             notificationState = .unavailable
             return
         }
-        UNUserNotificationCenter.current().getNotificationSettings { settings in
-            let status = settings.authorizationStatus
-            Task { @MainActor in
-                switch status {
-                case .authorized, .provisional, .ephemeral:
-                    self.notificationState = .enabled
-                case .denied:
-                    self.notificationState = .denied
-                default:
-                    self.notificationState = .notDetermined
-                }
+        Task { @MainActor in
+            let settings = await UNUserNotificationCenter.current().notificationSettings()
+            switch settings.authorizationStatus {
+            case .authorized, .provisional, .ephemeral:
+                self.notificationState = .enabled
+            case .denied:
+                self.notificationState = .denied
+            default:
+                self.notificationState = .notDetermined
             }
         }
     }


### PR DESCRIPTION
## What

Fixes the launch crash where AgentPet dies immediately with `EXC_BREAKPOINT (SIGTRAP)`. The same crash also fires when tapping **Enable Notifications** in Settings.

Closes #6.

## Why it crashes

`SettingsModel` is `@MainActor`. It used the **completion-handler** variants of two UserNotifications APIs:

- `getNotificationSettings { ... }` — invoked on launch from `refresh()`
- `requestAuthorization(...) { ... }` — invoked from `enableNotifications()`

The system delivers those completion handlers on a **background serial queue** (`com.apple.usernotifications.UNUserNotificationServiceConnection.call-out`). Because the surrounding context is main-actor-isolated, the Swift 6 compiler treats the closures as main-actor-isolated and inserts a runtime executor assertion at closure entry. When the handler runs on the background queue, `swift_task_isCurrentExecutorImpl` → `dispatch_assert_queue` fails and the runtime traps.

The pre-existing inner `Task { @MainActor in ... }` did not help: the assertion fires on the **outer** closure, before the `Task` is ever scheduled. Newer Swift runtimes enforce this isolation mismatch as a hard trap where older ones only warned — which is why a previously-working build began crashing.

Faulting backtrace:

```
EXC_BREAKPOINT (SIGTRAP)
Thread 1 queue: com.apple.usernotifications.UNUserNotificationServiceConnection.call-out
  _dispatch_assert_queue_fail
  dispatch_assert_queue
  swift_task_isCurrentExecutorImpl(swift::SerialExecutorRef)
  closure #1 in SettingsModel.refreshNotificationState()
  thunk for @escaping @callee_guaranteed (@guaranteed UNNotificationSettings) -> ()
```

## The fix

Use the `async` variants, awaited inside a `@MainActor Task`. Suspension resumes on the main actor, so no main-actor closure is ever executed on a background queue:

```swift
Task { @MainActor in
    let settings = await UNUserNotificationCenter.current().notificationSettings()
    switch settings.authorizationStatus { ... }
}
```

`UNNotificationSettings` is not `Sendable`, so under Swift 6 strict concurrency the import is marked `@preconcurrency import UserNotifications` (the compiler-suggested fix). This is safe: only `authorizationStatus` — a value-type enum — is read, and it is read on the main actor.

## Testing

- `swift build -c release` (universal arm64 + x86_64) succeeds with no warnings.
- Built the `.app` via `scripts/build-app.sh` and launched it: process stays alive, menu bar item appears, no new crash report in `~/Library/Logs/DiagnosticReports/`. Before the fix the same launch trapped within ~1s.
- Environment: macOS 15.3.2, Swift 6.1.2, AgentPet 1.1.7.

## Risk

Low. Behavior is unchanged — the notification status is still refreshed asynchronously and written to `@Published var notificationState` on the main actor. Only the API flavor (completion handler → async) and the import attribute changed.
