### PR TITLE
fix(installer): refuse to rewrite settings files that fail to parse

### DIFF
--- a/Sources/AgentPetCore/HookInstaller.swift
+++ b/Sources/AgentPetCore/HookInstaller.swift
@@ -1,5 +1,19 @@
 import Foundation
 
+/// Thrown when an agent's settings file exists but cannot be parsed as a JSON
+/// object. Rewriting it anyway would replace whatever the user had with just
+/// AgentPet's hooks, so install/uninstall refuse instead.
+public enum HookInstallerError: LocalizedError, Equatable {
+    case unreadableSettings(path: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unreadableSettings(let path):
+            return "\(path) is not valid JSON; fix or remove it and try again."
+        }
+    }
+}
+
 /// Installs/removes AgentPet's hook entries in an agent's config. Claude Code,
 /// Codex, and Gemini share the nested `{"hooks": {...}}` shape; Cursor and
 /// Windsurf use flatter JSON shapes; opencode uses a JS plugin file. The shape
@@ -149,10 +163,14 @@ public enum HookInstaller {
 
     // MARK: - Disk IO
 
-    public static func readSettings(path: String) -> [String: Any] {
-        guard let data = FileManager.default.contents(atPath: path),
-              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-        else { return [:] }
+    /// Reads an agent's settings file. A missing or empty file is an empty
+    /// config; a file with content that does not parse as a JSON object throws,
+    /// so callers never rewrite (and thereby wipe) settings they could not read.
+    public static func readSettings(path: String) throws -> [String: Any] {
+        guard let data = FileManager.default.contents(atPath: path), !data.isEmpty else { return [:] }
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw HookInstallerError.unreadableSettings(path: path)
+        }
         return obj
     }
 
@@ -196,9 +214,9 @@ public enum HookInstaller {
                                          events: [String] = events, style: HookStyle = .claudeNested) -> Bool {
         switch style {
         case .claudeNested:
-            return isInstalled(in: readSettings(path: path), events: events)
+            return isInstalled(in: (try? readSettings(path: path)) ?? [:], events: events)
         case .cursorFlat, .windsurfFlat:
-            return isInstalledFlat(in: readSettings(path: path), events: events)
+            return isInstalledFlat(in: (try? readSettings(path: path)) ?? [:], events: events)
         case .opencodePlugin:
             guard let s = try? String(contentsOfFile: path, encoding: .utf8) else { return false }
             return isOurs(s)

--- a/Tests/AgentPetCoreTests/HookInstallerTests.swift
+++ b/Tests/AgentPetCoreTests/HookInstallerTests.swift
@@ -57,4 +57,47 @@ final class HookInstallerTests: XCTestCase {
         try HookInstaller.uninstallFromDisk(path: path)
         XCTAssertFalse(HookInstaller.isInstalledOnDisk(path: path))
     }
+
+    // MARK: - Unreadable settings must never be rewritten
+
+    private func tempFile(_ contents: String) throws -> String {
+        let path = NSTemporaryDirectory() + "settings-\(UUID().uuidString).json"
+        try Data(contents.utf8).write(to: URL(fileURLWithPath: path))
+        return path
+    }
+
+    func testInstallRefusesToRewriteUnparseableSettings() throws {
+        let path = try tempFile("{ not json")
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        XCTAssertThrowsError(try HookInstaller.installToDisk(command: cmd, path: path)) {
+            XCTAssertEqual($0 as? HookInstallerError, .unreadableSettings(path: path))
+        }
+        XCTAssertEqual(try String(contentsOfFile: path, encoding: .utf8), "{ not json", "file untouched")
+    }
+
+    func testUninstallRefusesToRewriteUnparseableSettings() throws {
+        let path = try tempFile("{ not json")
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        XCTAssertThrowsError(try HookInstaller.uninstallFromDisk(path: path))
+        XCTAssertEqual(try String(contentsOfFile: path, encoding: .utf8), "{ not json", "file untouched")
+    }
+
+    func testInstallRefusesNonObjectRoot() throws {
+        let path = try tempFile("[1, 2, 3]")
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        XCTAssertThrowsError(try HookInstaller.installToDisk(command: cmd, path: path))
+    }
+
+    func testEmptyFileIsTreatedAsEmptySettings() throws {
+        let path = try tempFile("")
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        try HookInstaller.installToDisk(command: cmd, path: path)
+        XCTAssertTrue(HookInstaller.isInstalledOnDisk(path: path))
+    }
+
+    func testIsInstalledOnDiskIsFalseForUnreadableSettings() throws {
+        let path = try tempFile("{ not json")
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        XCTAssertFalse(HookInstaller.isInstalledOnDisk(path: path))
+    }
 }


### PR DESCRIPTION
## Problem

`HookInstaller.readSettings` returns `[:]` for **any** unreadable settings file — invalid JSON, non-object root, or a transiently truncated write. Install/uninstall then rewrite the file from that empty dict:

- **Install** → the file is replaced with only AgentPet's hooks, silently destroying the user's entire `~/.claude/settings.json` (model, permissions, other tools' hooks).
- **Uninstall** → the file is replaced with `{}`, wiping everything.

## Fix

`readSettings` now throws `HookInstallerError.unreadableSettings` when the file has content that does not parse as a JSON object, so `installToDisk` / `uninstallFromDisk` abort and leave the file untouched. Behavior kept lenient where it is safe:

- Missing file → empty config (unchanged)
- Empty file → empty config
- `isInstalledOnDisk` → `false` for unreadable files, never writes

## Tests

- install/uninstall on invalid JSON throw and leave the file byte-identical
- non-object root (`[1,2,3]`) is rejected
- empty file still installs fine
- `isInstalledOnDisk` is false (no throw) for unreadable files

Note: this PR and #(atomic-write PR) touch neighbouring lines in `HookInstaller.swift`'s Disk IO section — both are independent, whichever merges second may need a trivial rebase.