### PR TITLE
fix(installer): write settings and plugin files atomically

### DIFF
--- a/Sources/AgentPetCore/HookInstaller.swift
+++ b/Sources/AgentPetCore/HookInstaller.swift
@@ -160,7 +160,8 @@ public enum HookInstaller {
         let dir = (path as NSString).deletingLastPathComponent
         try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
         let data = try JSONSerialization.data(withJSONObject: settings, options: [.prettyPrinted, .sortedKeys])
-        try data.write(to: URL(fileURLWithPath: path))
+        // Atomic so a crash mid-write can never leave a truncated settings file.
+        try data.write(to: URL(fileURLWithPath: path), options: .atomic)
     }
 
     public static func installToDisk(command: String, path: String = defaultSettingsPath(),
@@ -174,7 +175,7 @@ public enum HookInstaller {
             let dir = (path as NSString).deletingLastPathComponent
             try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
             let js = opencodePlugin(binary: binaryPath(fromCommand: command))
-            try Data(js.utf8).write(to: URL(fileURLWithPath: path))
+            try Data(js.utf8).write(to: URL(fileURLWithPath: path), options: .atomic)
         }
     }
 


### PR DESCRIPTION
## Problem

`writeSettings` and the opencode plugin write use a plain truncate-and-write (`data.write(to:)` with no options). If the app crashes or is killed mid-write, the target — e.g. `~/.claude/settings.json` — is left truncated and unparseable.

## Fix

Pass `.atomic`: Foundation writes to a temp file and renames it into place, so at any point the file is either the complete old content or the complete new content, never a partial write. Applied to both the JSON settings write and the generated opencode plugin file.

No observable behavior change; the existing disk round-trip tests cover both paths (atomicity itself isn't black-box testable).

Related: #8 makes the read side refuse to rewrite a file it can't parse — together they close the corruption→wipe chain. Both PRs are independent; whichever merges second may need a trivial rebase (neighbouring lines in the Disk IO section).