### PR TITLE
fix(installer): match our hooks strictly and surface install errors

### DIFF
--- a/Sources/AgentPetCore/HookInstaller.swift
+++ b/Sources/AgentPetCore/HookInstaller.swift
@@ -17,8 +17,27 @@ public enum HookInstaller {
         NSHomeDirectory() + "/.claude/settings.json"
     }
 
+    /// True when a hook command is one AgentPet installed: the invoked binary
+    /// is named `agentpet` (any path, any case) and its first argument is the
+    /// `hook` subcommand. A plain substring check would also claim a user's own
+    /// hook whose path merely mentions agentpet (e.g.
+    /// `/Users/me/agentpet-experiments/my-hook.sh`) and delete it on uninstall.
     static func isOurs(_ command: String) -> Bool {
-        command.contains("agentpet") && command.contains("hook")
+        let trimmed = command.trimmingCharacters(in: .whitespaces)
+        let binary: String
+        let rest: String
+        if trimmed.hasPrefix("\"") {
+            let afterQuote = trimmed.dropFirst()
+            guard let close = afterQuote.firstIndex(of: "\"") else { return false }
+            binary = String(afterQuote[..<close])
+            rest = String(afterQuote[afterQuote.index(after: close)...])
+        } else {
+            let parts = trimmed.split(separator: " ", maxSplits: 1)
+            binary = parts.first.map(String.init) ?? ""
+            rest = parts.count > 1 ? String(parts[1]) : ""
+        }
+        guard (binary as NSString).lastPathComponent.lowercased() == "agentpet" else { return false }
+        return rest.split(separator: " ").first == "hook"
     }
 
     // MARK: - Claude-nested shape (Claude / Codex / Gemini)
@@ -200,8 +219,10 @@ public enum HookInstaller {
         case .cursorFlat, .windsurfFlat:
             return isInstalledFlat(in: readSettings(path: path), events: events)
         case .opencodePlugin:
+            // The generated plugin always declares AGENTPET_BIN; a user's own
+            // plugin file won't, so it is never mistaken for ours (and deleted).
             guard let s = try? String(contentsOfFile: path, encoding: .utf8) else { return false }
-            return isOurs(s)
+            return s.contains("AGENTPET_BIN")
         }
     }
 }

--- a/Sources/App/OnboardingView.swift
+++ b/Sources/App/OnboardingView.swift
@@ -104,6 +104,9 @@ struct OnboardingView: View {
                     .disabled(model.isInstalled(agent.kind))
                 }
             }
+            if let error = model.lastHookError {
+                Text(error).font(.caption).foregroundStyle(.red)
+            }
         }
         .themedCard()
     }

--- a/Sources/App/SettingsModel.swift
+++ b/Sources/App/SettingsModel.swift
@@ -19,6 +19,10 @@ final class SettingsModel: ObservableObject {
     @Published private(set) var notificationState: NotificationState = .notDetermined
     @Published private(set) var installedKinds: Set<AgentKind> = []
 
+    /// Why the last install/uninstall failed (e.g. an unwritable or corrupt
+    /// settings file), shown next to the agent list. Cleared on success.
+    @Published private(set) var lastHookError: String?
+
     /// In-app notification toggle: lets users mute alerts even after granting
     /// the macOS permission. Defaults to on.
     @Published var notificationsEnabled: Bool {
@@ -72,10 +76,15 @@ final class SettingsModel: ObservableObject {
 
     func toggleInstall(_ kind: AgentKind) {
         guard let spec = AgentHooks.spec(for: kind) else { return }
-        if installedKinds.contains(kind) {
-            try? HookInstaller.uninstallFromDisk(path: spec.settingsPath, events: spec.events, style: spec.style)
-        } else {
-            try? HookInstaller.installToDisk(command: hookCommand(for: kind), path: spec.settingsPath, events: spec.events, style: spec.style)
+        do {
+            if installedKinds.contains(kind) {
+                try HookInstaller.uninstallFromDisk(path: spec.settingsPath, events: spec.events, style: spec.style)
+            } else {
+                try HookInstaller.installToDisk(command: hookCommand(for: kind), path: spec.settingsPath, events: spec.events, style: spec.style)
+            }
+            lastHookError = nil
+        } catch {
+            lastHookError = error.localizedDescription
         }
         refresh()
     }

--- a/Sources/App/SetupView.swift
+++ b/Sources/App/SetupView.swift
@@ -283,6 +283,9 @@ private struct GeneralTab: View {
                         }
                     }
                 }
+                if let error = model.lastHookError {
+                    Text(error).font(.caption).foregroundStyle(.red)
+                }
             }
 
             Section("About") {

--- a/Tests/AgentPetCoreTests/HookInstallerTests.swift
+++ b/Tests/AgentPetCoreTests/HookInstallerTests.swift
@@ -49,6 +49,29 @@ final class HookInstallerTests: XCTestCase {
         XCTAssertNil(removed["hooks"])
     }
 
+    // MARK: - Ownership matching
+
+    func testIsOursMatchesInstalledCommandShapes() {
+        // Quoted bundle path, with and without the v1-era missing --agent flag.
+        XCTAssertTrue(HookInstaller.isOurs("\"/Applications/AgentPet.app/Contents/MacOS/agentpet\" hook"))
+        XCTAssertTrue(HookInstaller.isOurs("\"/Applications/AgentPet.app/Contents/MacOS/AgentPet\" hook --agent codex"))
+        // Unquoted binary on PATH.
+        XCTAssertTrue(HookInstaller.isOurs("/usr/local/bin/agentpet hook --agent claude"))
+        XCTAssertTrue(HookInstaller.isOurs("agentpet hook"))
+    }
+
+    func testIsOursRejectsForeignCommands() {
+        // A user's own hook whose path merely mentions agentpet.
+        XCTAssertFalse(HookInstaller.isOurs("/Users/me/agentpet-experiments/my-hook.sh"))
+        XCTAssertFalse(HookInstaller.isOurs("\"/Users/me/agentpet-tools/run-hooks.sh\" hook"))
+        // Right words, wrong binary.
+        XCTAssertFalse(HookInstaller.isOurs("echo agentpet hook done"))
+        // Our binary, different subcommand.
+        XCTAssertFalse(HookInstaller.isOurs("\"/Applications/AgentPet.app/Contents/MacOS/agentpet\" run -- make"))
+        XCTAssertFalse(HookInstaller.isOurs("agentpet"))
+        XCTAssertFalse(HookInstaller.isOurs(""))
+    }
+
     func testDiskRoundTrip() throws {
         let path = NSTemporaryDirectory() + "settings-\(UUID().uuidString).json"
         defer { try? FileManager.default.removeItem(atPath: path) }

--- a/Tests/AgentPetCoreTests/MultiAgentHookTests.swift
+++ b/Tests/AgentPetCoreTests/MultiAgentHookTests.swift
@@ -58,7 +58,9 @@ final class MultiAgentHookTests: XCTestCase {
         XCTAssertTrue(js.contains("session.created"))
         XCTAssertTrue(js.contains("--agent"))
         XCTAssertTrue(js.contains("opencode"))
-        XCTAssertTrue(HookInstaller.isOurs(js.replacingOccurrences(of: "\n", with: " ")))
+        // On-disk detection keys off the generated AGENTPET_BIN marker (a JS
+        // file is not a hook command, so isOurs does not apply to it).
+        XCTAssertTrue(js.contains("AGENTPET_BIN"))
     }
 
     // MARK: - Payload parsing


### PR DESCRIPTION
## Problem 1 — `isOurs` can delete a user's own hooks

`isOurs` claims any command containing both substrings `agentpet` and `hook`:

```swift
command.contains("agentpet") && command.contains("hook")
```

A user hook like `/Users/me/agentpet-experiments/my-hook.sh` matches and gets **silently deleted** on uninstall or reinstall.

## Fix 1

`isOurs` now parses the command: the invoked binary must be named `agentpet` (any path, case-insensitive — covers both `agentpet` and the bundled `AgentPet`) and its first argument must be the `hook` subcommand. This matches every command shape AgentPet has ever installed (quoted/unquoted, with/without the v1-era `--agent` flag) and rejects look-alikes.

opencode plugin detection no longer runs the command matcher over JS source; it keys off the generated `AGENTPET_BIN` marker instead, so a user's own plugin file is never mistaken for ours and deleted.

## Problem 2 — install failures are swallowed

`SettingsModel.toggleInstall` wrapped install/uninstall in `try?`, so a failure (unwritable path, corrupt settings) looked like success in Settings and onboarding.

## Fix 2

`toggleInstall` records `error.localizedDescription` in a published `lastHookError` (cleared on success); Settings and the onboarding agent step show it under the agent list.

## Tests

- `isOurs` accepts all historically-installed command shapes (quoted bundle path, unquoted PATH binary, with/without `--agent`)
- `isOurs` rejects foreign commands: path-mentions-agentpet scripts, `echo agentpet hook done`, our binary with a different subcommand
- opencode plugin content/disk round-trip updated to the marker-based detection