### PR TITLE
Bubble for multi agent mode

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,5 +22,10 @@ let package = Package(
             dependencies: ["AgentPetCore"],
             path: "Tests/AgentPetCoreTests"
         ),
+        .testTarget(
+            name: "AgentPetAppTests",
+            dependencies: ["agentpet"],
+            path: "Tests/AgentPetAppTests"
+        ),
     ]
 )

--- a/Sources/AgentPetCore/AgentEvent.swift
+++ b/Sources/AgentPetCore/AgentEvent.swift
@@ -9,6 +9,9 @@ public struct AgentEvent: Codable, Sendable, Equatable {
     public var eventName: String
     public var project: String?
     public var message: String?
+    /// Path to the agent's conversation transcript file (e.g. Claude Code JSONL).
+    /// Used to derive a human-readable title for the session.
+    public var transcriptPath: String?
     public var timestamp: Date
 
     public init(
@@ -17,6 +20,7 @@ public struct AgentEvent: Codable, Sendable, Equatable {
         eventName: String,
         project: String? = nil,
         message: String? = nil,
+        transcriptPath: String? = nil,
         timestamp: Date
     ) {
         self.sessionId = sessionId
@@ -24,6 +28,7 @@ public struct AgentEvent: Codable, Sendable, Equatable {
         self.eventName = eventName
         self.project = project
         self.message = message
+        self.transcriptPath = transcriptPath
         self.timestamp = timestamp
     }
 }

--- a/Sources/AgentPetCore/AgentSession.swift
+++ b/Sources/AgentPetCore/AgentSession.swift
@@ -5,6 +5,9 @@ public struct AgentSession: Identifiable, Sendable, Equatable {
     public let id: String
     public var agentKind: AgentKind
     public var project: String?
+    /// Human-readable conversation title (e.g. Claude Code's summary, or first
+    /// user message). Populated lazily from the transcript when available.
+    public var title: String?
     public var state: AgentState
     public var message: String?
     public var source: AgentSource
@@ -16,6 +19,7 @@ public struct AgentSession: Identifiable, Sendable, Equatable {
         id: String,
         agentKind: AgentKind,
         project: String? = nil,
+        title: String? = nil,
         state: AgentState,
         message: String? = nil,
         source: AgentSource,
@@ -25,6 +29,7 @@ public struct AgentSession: Identifiable, Sendable, Equatable {
         self.id = id
         self.agentKind = agentKind
         self.project = project
+        self.title = title
         self.state = state
         self.message = message
         self.source = source

--- a/Sources/AgentPetCore/ClaudeActivityFormatter.swift
+++ b/Sources/AgentPetCore/ClaudeActivityFormatter.swift
@@ -1,0 +1,170 @@
+import Foundation
+
+/// Tool arguments Claude Code sends on PreToolUse / PostToolUse hooks.
+public struct ClaudeToolInput: Decodable, Equatable, Sendable {
+    public let filePath: String?
+    public let command: String?
+    public let description: String?
+    public let pattern: String?
+    public let query: String?
+    public let url: String?
+    public let prompt: String?
+    public let subagentType: String?
+
+    enum CodingKeys: String, CodingKey {
+        case filePath = "file_path"
+        case command, description, pattern, query, url, prompt
+        case subagentType = "subagent_type"
+    }
+}
+
+/// Turns Claude Code hook payloads into whimsical activity lines
+/// (e.g. "Cooking…", "Sprouting…") instead of file paths or tool names.
+public enum ClaudeActivityFormatter {
+
+    public static func activityMessage(
+        eventName: String,
+        sessionId: String,
+        toolName: String?,
+        toolInput: ClaudeToolInput?,
+        explicitMessage: String?
+    ) -> String? {
+        if eventName == "Notification" {
+            return trimmed(explicitMessage)
+        }
+
+        switch eventName {
+        case "UserPromptSubmit":
+            return pick(from: thinking, seed: seed(sessionId, eventName, toolName, toolInput))
+        case "PreToolUse", "PostToolUse":
+            return toolActivity(
+                sessionId: sessionId,
+                eventName: eventName,
+                toolName: toolName,
+                toolInput: toolInput
+            )
+        default:
+            if let toolName {
+                return toolActivity(
+                    sessionId: sessionId,
+                    eventName: eventName,
+                    toolName: toolName,
+                    toolInput: toolInput
+                )
+            }
+            return trimmed(explicitMessage)
+        }
+    }
+
+    private static let thinking = [
+        "Photosynthesizing…",
+        "Sprouting…",
+        "Planning…",
+        "Pondering…",
+        "Germinating…",
+        "Marinating…",
+        "Noodling…",
+    ]
+
+    private static let reading = [
+        "Perusing…",
+        "Leafing through…",
+        "Absorbing…",
+        "Studying…",
+        "Browsing…",
+    ]
+
+    private static let writing = [
+        "Cooking…",
+        "Baking…",
+        "Crafting…",
+        "Whittling…",
+        "Sculpting…",
+        "Stitching…",
+    ]
+
+    private static let running = [
+        "Brewing…",
+        "Simmering…",
+        "Stirring the pot…",
+        "Running the numbers…",
+    ]
+
+    private static let searching = [
+        "Foraging…",
+        "Scouting…",
+        "Hunting…",
+        "Exploring…",
+        "Investigating…",
+    ]
+
+    private static let delegating = [
+        "Delegating…",
+        "Hatching a plan…",
+        "Spawning help…",
+        "Rounding up agents…",
+    ]
+
+    private static let generic = [
+        "Working…",
+        "Tinkering…",
+        "Doing the thing…",
+    ]
+
+    private static func toolActivity(
+        sessionId: String,
+        eventName: String,
+        toolName: String?,
+        toolInput: ClaudeToolInput?
+    ) -> String? {
+        guard let toolName else { return nil }
+        let phrases: [String]
+        switch toolName {
+        case "Read":
+            phrases = reading
+        case "Edit", "Write", "MultiEdit":
+            phrases = writing
+        case "Bash":
+            phrases = running
+        case "Glob", "Grep", "WebSearch", "WebFetch":
+            phrases = searching
+        case "Agent", "Task":
+            phrases = delegating
+        case "Skill":
+            phrases = ["Consulting the scrolls…", "Channeling a skill…", "Reading the manual…"]
+        default:
+            phrases = generic
+        }
+        return pick(from: phrases, seed: seed(sessionId, eventName, toolName, toolInput))
+    }
+
+    private static func seed(
+        _ sessionId: String,
+        _ eventName: String,
+        _ toolName: String?,
+        _ toolInput: ClaudeToolInput?
+    ) -> String {
+        [
+            sessionId,
+            eventName,
+            toolName ?? "",
+            toolInput?.filePath ?? "",
+            toolInput?.command ?? "",
+            toolInput?.pattern ?? "",
+            toolInput?.query ?? "",
+        ].joined(separator: "|")
+    }
+
+    private static func pick(from phrases: [String], seed: String) -> String {
+        guard !phrases.isEmpty else { return "Working…" }
+        let hash = seed.utf8.reduce(5381) { ($0 << 5) &+ $0 &+ Int($1) }
+        return phrases[abs(hash) % phrases.count]
+    }
+
+    private static func trimmed(_ text: String?) -> String? {
+        guard let text = text?.trimmingCharacters(in: .whitespacesAndNewlines), !text.isEmpty else {
+            return nil
+        }
+        return text
+    }
+}

--- a/Sources/AgentPetCore/ClaudeActivityFormatter.swift
+++ b/Sources/AgentPetCore/ClaudeActivityFormatter.swift
@@ -11,6 +11,16 @@ public struct ClaudeToolInput: Decodable, Equatable, Sendable {
     public let prompt: String?
     public let subagentType: String?
 
+    public init(
+        filePath: String? = nil, command: String? = nil, description: String? = nil,
+        pattern: String? = nil, query: String? = nil, url: String? = nil,
+        prompt: String? = nil, subagentType: String? = nil
+    ) {
+        self.filePath = filePath; self.command = command; self.description = description
+        self.pattern = pattern; self.query = query; self.url = url
+        self.prompt = prompt; self.subagentType = subagentType
+    }
+
     enum CodingKeys: String, CodingKey {
         case filePath = "file_path"
         case command, description, pattern, query, url, prompt
@@ -35,22 +45,12 @@ public enum ClaudeActivityFormatter {
 
         switch eventName {
         case "UserPromptSubmit":
-            return pick(from: thinking, seed: seed(sessionId, eventName, toolName, toolInput))
+            return pick(from: thinking, key: eventName)
         case "PreToolUse", "PostToolUse":
-            return toolActivity(
-                sessionId: sessionId,
-                eventName: eventName,
-                toolName: toolName,
-                toolInput: toolInput
-            )
+            return toolActivity(toolName: toolName, toolInput: toolInput)
         default:
-            if let toolName {
-                return toolActivity(
-                    sessionId: sessionId,
-                    eventName: eventName,
-                    toolName: toolName,
-                    toolInput: toolInput
-                )
+            if toolName != nil {
+                return toolActivity(toolName: toolName, toolInput: toolInput)
             }
             return trimmed(explicitMessage)
         }
@@ -112,12 +112,11 @@ public enum ClaudeActivityFormatter {
     ]
 
     private static func toolActivity(
-        sessionId: String,
-        eventName: String,
         toolName: String?,
         toolInput: ClaudeToolInput?
     ) -> String? {
         guard let toolName else { return nil }
+        if let hint = extensionHint(toolName: toolName, filePath: toolInput?.filePath) { return hint }
         let phrases: [String]
         switch toolName {
         case "Read":
@@ -135,30 +134,49 @@ public enum ClaudeActivityFormatter {
         default:
             phrases = generic
         }
-        return pick(from: phrases, seed: seed(sessionId, eventName, toolName, toolInput))
+        return pick(from: phrases, key: toolName)
     }
 
-    private static func seed(
-        _ sessionId: String,
-        _ eventName: String,
-        _ toolName: String?,
-        _ toolInput: ClaudeToolInput?
-    ) -> String {
-        [
-            sessionId,
-            eventName,
-            toolName ?? "",
-            toolInput?.filePath ?? "",
-            toolInput?.command ?? "",
-            toolInput?.pattern ?? "",
-            toolInput?.query ?? "",
-        ].joined(separator: "|")
+    private static func extensionHint(toolName: String, filePath: String?) -> String? {
+        guard let path = filePath else { return nil }
+        let lower = path.lowercased()
+        let isTest = lower.contains("tests/") || lower.hasSuffix("tests.swift") || lower.hasSuffix("test.swift")
+        let isDoc  = lower.hasSuffix(".md") || lower.hasSuffix(".txt") || lower.hasSuffix(".rst")
+        let isCfg  = lower.hasSuffix(".json") || lower.hasSuffix(".yaml") || lower.hasSuffix(".yml")
+                  || lower.hasSuffix(".plist") || lower.hasSuffix(".toml")
+        let isRead  = toolName == "Read"
+        let isWrite = toolName == "Edit" || toolName == "Write" || toolName == "MultiEdit"
+        if isTest  && isRead  { return "Reviewing tests…" }
+        if isTest  && isWrite { return "Refining tests…" }
+        if isDoc   && isRead  { return "Reading the docs…" }
+        if isDoc   && isWrite { return "Updating the docs…" }
+        if isCfg   && isRead  { return "Parsing config…" }
+        if isCfg   && isWrite { return "Adjusting config…" }
+        return nil
     }
 
-    private static func pick(from phrases: [String], seed: String) -> String {
+    private static let doneMessages = [
+        "All done!", "Wrapped up!", "Delivered!", "Finished!", "Mission complete!",
+    ]
+    private static let waitingMessages = [
+        "Awaiting instructions…", "Standing by…", "Listening…",
+    ]
+
+    public static func stateMessage(for state: AgentState) -> String? {
+        switch state {
+        case .done:    return pick(from: doneMessages,    key: "state.done")
+        case .waiting: return pick(from: waitingMessages, key: "state.waiting")
+        default:       return nil
+        }
+    }
+
+    nonisolated(unsafe) private static var callCounts: [String: Int] = [:]
+
+    private static func pick(from phrases: [String], key: String) -> String {
         guard !phrases.isEmpty else { return "Working…" }
-        let hash = seed.utf8.reduce(5381) { ($0 << 5) &+ $0 &+ Int($1) }
-        return phrases[abs(hash) % phrases.count]
+        let n = (callCounts[key, default: 0] + 1) % phrases.count
+        callCounts[key] = n
+        return phrases[n]
     }
 
     private static func trimmed(_ text: String?) -> String? {

--- a/Sources/AgentPetCore/ClaudeActivityFormatter.swift
+++ b/Sources/AgentPetCore/ClaudeActivityFormatter.swift
@@ -28,9 +28,142 @@ public struct ClaudeToolInput: Decodable, Equatable, Sendable {
     }
 }
 
-/// Turns Claude Code hook payloads into whimsical activity lines
-/// (e.g. "Cooking…", "Sprouting…") instead of file paths or tool names.
+// MARK: - Activity Theme
+
+public enum ActivityTheme: String, CaseIterable, Codable, Sendable {
+    case chef, engineer, wizard, explorer, scientist
+
+    public var displayName: String {
+        switch self {
+        case .chef:      return "Chef"
+        case .engineer:  return "Engineer"
+        case .wizard:    return "Wizard"
+        case .explorer:  return "Explorer"
+        case .scientist: return "Scientist"
+        }
+    }
+
+    public var emoji: String {
+        switch self {
+        case .chef:      return "👨‍🍳"
+        case .engineer:  return "⚙️"
+        case .wizard:    return "🧙"
+        case .explorer:  return "🧭"
+        case .scientist: return "🔬"
+        }
+    }
+
+    // MARK: Phrase pools
+
+    var reading: [String] {
+        switch self {
+        case .chef:      return ["Perusing…", "Leafing through…", "Absorbing…", "Studying…", "Browsing…"]
+        case .engineer:  return ["Inspecting…", "Reviewing…", "Parsing…", "Auditing…", "Loading…"]
+        case .wizard:    return ["Studying the scrolls…", "Deciphering…", "Consulting the tome…", "Peering within…"]
+        case .explorer:  return ["Surveying…", "Mapping the terrain…", "Examining the site…", "Charting…"]
+        case .scientist: return ["Observing…", "Reviewing the data…", "Analyzing the sample…", "Examining…"]
+        }
+    }
+
+    var writing: [String] {
+        switch self {
+        case .chef:      return ["Cooking…", "Baking…", "Crafting…", "Whittling…", "Sculpting…", "Stitching…"]
+        case .engineer:  return ["Refactoring…", "Implementing…", "Patching…", "Scaffolding…", "Committing…"]
+        case .wizard:    return ["Inscribing…", "Enchanting…", "Weaving a spell…", "Scribing…"]
+        case .explorer:  return ["Logging the expedition…", "Marking the map…", "Recording findings…", "Documenting…"]
+        case .scientist: return ["Synthesizing…", "Documenting findings…", "Writing the report…", "Formulating…"]
+        }
+    }
+
+    var running: [String] {
+        switch self {
+        case .chef:      return ["Brewing…", "Simmering…", "Stirring the pot…", "Running the numbers…"]
+        case .engineer:  return ["Compiling…", "Building…", "Executing…", "Deploying…", "Running the pipeline…"]
+        case .wizard:    return ["Casting…", "Invoking…", "Summoning…", "Channeling magic…"]
+        case .explorer:  return ["Blazing a trail…", "Trekking…", "Venturing forth…", "Pushing on…"]
+        case .scientist: return ["Running the experiment…", "Executing the protocol…", "Testing the hypothesis…", "Processing…"]
+        }
+    }
+
+    var searching: [String] {
+        switch self {
+        case .chef:      return ["Foraging…", "Scouting…", "Hunting…", "Exploring…", "Investigating…"]
+        case .engineer:  return ["Scanning…", "Grepping…", "Indexing…", "Tracing…", "Profiling…"]
+        case .wizard:    return ["Divining…", "Scrying…", "Seeking…", "Gazing into the orb…"]
+        case .explorer:  return ["Scouting ahead…", "Seeking passage…", "Exploring…", "Reconnoitering…"]
+        case .scientist: return ["Scanning the dataset…", "Cross-referencing…", "Searching for patterns…", "Correlating…"]
+        }
+    }
+
+    var delegating: [String] {
+        switch self {
+        case .chef:      return ["Delegating…", "Hatching a plan…", "Spawning help…", "Rounding up agents…"]
+        case .engineer:  return ["Spawning a process…", "Forking…", "Dispatching…", "Queueing a job…"]
+        case .wizard:    return ["Calling forth…", "Summoning a familiar…", "Conjuring help…"]
+        case .explorer:  return ["Sending a scout…", "Dispatching a guide…", "Rallying the crew…"]
+        case .scientist: return ["Assigning to the lab…", "Tasking the team…", "Delegating to an assistant…"]
+        }
+    }
+
+    var thinking: [String] {
+        switch self {
+        case .chef:      return ["Photosynthesizing…", "Sprouting…", "Planning…", "Pondering…", "Germinating…", "Marinating…", "Noodling…"]
+        case .engineer:  return ["Architecting…", "Designing…", "Calculating…", "Debugging…", "Optimizing…"]
+        case .wizard:    return ["Meditating…", "Pondering the arcane…", "Consulting the stars…", "Prophesying…"]
+        case .explorer:  return ["Plotting a course…", "Reading the stars…", "Studying the map…", "Planning the route…"]
+        case .scientist: return ["Hypothesizing…", "Theorizing…", "Modeling…", "Calculating…", "Reasoning…"]
+        }
+    }
+
+    var done: [String] {
+        switch self {
+        case .chef:      return ["All done!", "Wrapped up!", "Delivered!", "Finished!", "Mission complete!"]
+        case .engineer:  return ["Build complete!", "Shipped!", "Merged!", "All green!", "Tests passing!"]
+        case .wizard:    return ["The spell is cast!", "It is done!", "Magic complete!", "Quest fulfilled!"]
+        case .explorer:  return ["Base camp reached!", "Trail blazed!", "Discovery made!", "Expedition complete!"]
+        case .scientist: return ["Hypothesis confirmed!", "Results in!", "Experiment complete!", "Published!"]
+        }
+    }
+
+    var waiting: [String] {
+        switch self {
+        case .chef:      return ["Awaiting instructions…", "Standing by…", "Listening…"]
+        case .engineer:  return ["Awaiting input…", "Blocked on dependency…", "Polling…"]
+        case .wizard:    return ["Awaiting the omens…", "The stars are aligning…", "Patience, young apprentice…"]
+        case .explorer:  return ["Awaiting the tide…", "Resting at camp…", "Holding position…"]
+        case .scientist: return ["Awaiting results…", "Incubating…", "Waiting for the reaction…"]
+        }
+    }
+
+    var skill: [String] {
+        switch self {
+        case .chef:      return ["Consulting the recipe…", "Checking the cookbook…", "Following the method…"]
+        case .engineer:  return ["Reading the manual…", "Checking the docs…", "Loading the module…"]
+        case .wizard:    return ["Consulting the scrolls…", "Channeling a skill…", "Reading the grimoire…"]
+        case .explorer:  return ["Consulting the guide…", "Reading the field notes…", "Checking the compass…"]
+        case .scientist: return ["Consulting the protocol…", "Reviewing the literature…", "Checking the procedure…"]
+        }
+    }
+
+    var generic: [String] {
+        switch self {
+        case .chef:      return ["Working…", "Tinkering…", "Doing the thing…"]
+        case .engineer:  return ["Processing…", "Running…", "Executing…"]
+        case .wizard:    return ["Weaving…", "Working the magic…", "At work…"]
+        case .explorer:  return ["Moving forward…", "Pressing on…", "On the trail…"]
+        case .scientist: return ["Analyzing…", "Processing…", "At work…"]
+        }
+    }
+}
+
+// MARK: - Formatter
+
+/// Turns Claude Code hook payloads into whimsical activity lines.
+/// Vocabulary is controlled by `currentTheme` (default: `.chef`).
 public enum ClaudeActivityFormatter {
+
+    /// Set from `BubbleSettings.activityTheme.didSet` on the main thread.
+    public nonisolated(unsafe) static var currentTheme: ActivityTheme = .chef
 
     public static func activityMessage(
         eventName: String,
@@ -42,10 +175,9 @@ public enum ClaudeActivityFormatter {
         if eventName == "Notification" {
             return trimmed(explicitMessage)
         }
-
         switch eventName {
         case "UserPromptSubmit":
-            return pick(from: thinking, key: eventName)
+            return pick(from: currentTheme.thinking, key: eventName)
         case "PreToolUse", "PostToolUse":
             return toolActivity(toolName: toolName, toolInput: toolInput)
         default:
@@ -56,83 +188,35 @@ public enum ClaudeActivityFormatter {
         }
     }
 
-    private static let thinking = [
-        "Photosynthesizing…",
-        "Sprouting…",
-        "Planning…",
-        "Pondering…",
-        "Germinating…",
-        "Marinating…",
-        "Noodling…",
-    ]
+    public static func stateMessage(for state: AgentState) -> String? {
+        switch state {
+        case .done:    return pick(from: currentTheme.done,    key: "state.done")
+        case .waiting: return pick(from: currentTheme.waiting, key: "state.waiting")
+        default:       return nil
+        }
+    }
 
-    private static let reading = [
-        "Perusing…",
-        "Leafing through…",
-        "Absorbing…",
-        "Studying…",
-        "Browsing…",
-    ]
+    // MARK: Private
 
-    private static let writing = [
-        "Cooking…",
-        "Baking…",
-        "Crafting…",
-        "Whittling…",
-        "Sculpting…",
-        "Stitching…",
-    ]
-
-    private static let running = [
-        "Brewing…",
-        "Simmering…",
-        "Stirring the pot…",
-        "Running the numbers…",
-    ]
-
-    private static let searching = [
-        "Foraging…",
-        "Scouting…",
-        "Hunting…",
-        "Exploring…",
-        "Investigating…",
-    ]
-
-    private static let delegating = [
-        "Delegating…",
-        "Hatching a plan…",
-        "Spawning help…",
-        "Rounding up agents…",
-    ]
-
-    private static let generic = [
-        "Working…",
-        "Tinkering…",
-        "Doing the thing…",
-    ]
-
-    private static func toolActivity(
-        toolName: String?,
-        toolInput: ClaudeToolInput?
-    ) -> String? {
+    private static func toolActivity(toolName: String?, toolInput: ClaudeToolInput?) -> String? {
         guard let toolName else { return nil }
         if let hint = extensionHint(toolName: toolName, filePath: toolInput?.filePath) { return hint }
         let phrases: [String]
         switch toolName {
         case "Read":
-            phrases = reading
+            phrases = currentTheme.reading
         case "Edit", "Write", "MultiEdit":
-            phrases = writing
+            phrases = currentTheme.writing
         case "Bash":
-            phrases = running
+            phrases = currentTheme.running
         case "Glob", "Grep", "WebSearch", "WebFetch":
-            phrases = searching
+            phrases = currentTheme.searching
         case "Agent", "Task":
-            phrases = delegating
+            phrases = currentTheme.delegating
         case "Skill":
-            phrases = ["Consulting the scrolls…", "Channeling a skill…", "Reading the manual…"]
+            phrases = currentTheme.skill
         default:
-            phrases = generic
+            phrases = currentTheme.generic
         }
         return pick(from: phrases, key: toolName)
     }
@@ -153,21 +237,6 @@ public enum ClaudeActivityFormatter {
         if isCfg   && isRead  { return "Parsing config…" }
         if isCfg   && isWrite { return "Adjusting config…" }
         return nil
-    }
-
-    private static let doneMessages = [
-        "All done!", "Wrapped up!", "Delivered!", "Finished!", "Mission complete!",
-    ]
-    private static let waitingMessages = [
-        "Awaiting instructions…", "Standing by…", "Listening…",
-    ]
-
-    public static func stateMessage(for state: AgentState) -> String? {
-        switch state {
-        case .done:    return pick(from: doneMessages,    key: "state.done")
-        case .waiting: return pick(from: waitingMessages, key: "state.waiting")
-        default:       return nil
-        }
     }
 
     nonisolated(unsafe) private static var callCounts: [String: Int] = [:]

--- a/Sources/AgentPetCore/ClaudeHookPayload.swift
+++ b/Sources/AgentPetCore/ClaudeHookPayload.swift
@@ -8,6 +8,7 @@ public struct ClaudeHookPayload: Decodable, Equatable {
     public let hookEventName: String?
     public let message: String?
     public let toolName: String?
+    public let toolInput: ClaudeToolInput?
     /// Absolute path to the conversation's JSONL transcript file.
     public let transcriptPath: String?
 
@@ -17,6 +18,7 @@ public struct ClaudeHookPayload: Decodable, Equatable {
         case hookEventName = "hook_event_name"
         case message
         case toolName = "tool_name"
+        case toolInput = "tool_input"
         case transcriptPath = "transcript_path"
     }
 
@@ -28,8 +30,13 @@ public struct ClaudeHookPayload: Decodable, Equatable {
     /// fields (session id and event name) are missing.
     public func makeEvent(now: Date, kind: AgentKind = .claude) -> AgentEvent? {
         guard let sessionId, let hookEventName else { return nil }
-        // Surface the running tool name when there's no explicit message.
-        let context = message ?? toolName.map { "Using \($0)" }
+        let context = ClaudeActivityFormatter.activityMessage(
+            eventName: hookEventName,
+            sessionId: sessionId,
+            toolName: toolName,
+            toolInput: toolInput,
+            explicitMessage: message
+        ) ?? toolName.map { "Using \($0)" }
         return AgentEvent(
             sessionId: sessionId, agentKind: kind, eventName: hookEventName,
             project: cwd, message: context, transcriptPath: transcriptPath, timestamp: now

--- a/Sources/AgentPetCore/ClaudeHookPayload.swift
+++ b/Sources/AgentPetCore/ClaudeHookPayload.swift
@@ -8,6 +8,8 @@ public struct ClaudeHookPayload: Decodable, Equatable {
     public let hookEventName: String?
     public let message: String?
     public let toolName: String?
+    /// Absolute path to the conversation's JSONL transcript file.
+    public let transcriptPath: String?
 
     enum CodingKeys: String, CodingKey {
         case sessionId = "session_id"
@@ -15,6 +17,7 @@ public struct ClaudeHookPayload: Decodable, Equatable {
         case hookEventName = "hook_event_name"
         case message
         case toolName = "tool_name"
+        case transcriptPath = "transcript_path"
     }
 
     public static func decode(from data: Data) -> ClaudeHookPayload? {
@@ -29,7 +32,7 @@ public struct ClaudeHookPayload: Decodable, Equatable {
         let context = message ?? toolName.map { "Using \($0)" }
         return AgentEvent(
             sessionId: sessionId, agentKind: kind, eventName: hookEventName,
-            project: cwd, message: context, timestamp: now
+            project: cwd, message: context, transcriptPath: transcriptPath, timestamp: now
         )
     }
 }

--- a/Sources/AgentPetCore/QuestionDetector.swift
+++ b/Sources/AgentPetCore/QuestionDetector.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Detects whether a piece of assistant text reads like Claude ended its turn
+/// by asking the user something — as opposed to simply reporting completion.
+///
+/// Pure string logic: no I/O, no actor isolation. Used to correct a session's
+/// state from `.done` to `.waiting` when Claude's `Stop` hook fires after a
+/// turn that actually ended in a question (Claude Code sends no separate event
+/// for "I asked the user something and am waiting for a reply").
+public enum QuestionDetector {
+    private static let directionPhrases = [
+        "let me know",
+        "should i",
+        "which would you",
+        "do you want",
+        "want me to",
+        "shall i",
+        "would you like"
+    ]
+
+    /// True if `text` looks like a request for the user's direction: it ends
+    /// with a question mark, or contains a recognizable "asking what to do
+    /// next" phrase.
+    public static func looksLikeQuestion(_ text: String) -> Bool {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        if trimmed.hasSuffix("?") { return true }
+        let lowered = trimmed.lowercased()
+        return directionPhrases.contains { lowered.contains($0) }
+    }
+}

--- a/Sources/AgentPetCore/SessionStore.swift
+++ b/Sources/AgentPetCore/SessionStore.swift
@@ -47,6 +47,22 @@ public final class SessionStore {
         byID[id]?.title = title
     }
 
+    /// Corrects a session's state after the fact — used when an async check
+    /// (e.g. reading the transcript to see how Claude ended its turn)
+    /// determines the state we set synchronously was wrong.
+    ///
+    /// Only applies when the session is *still* in `expected` state from the
+    /// *same* transition (`since` matches `stateSince`): if a newer event has
+    /// already moved the session on, this is a no-op — the correction targets
+    /// a transition that no longer exists, and must never clobber fresher
+    /// state. `stateSince` is preserved (this corrects the existing
+    /// transition; it isn't a new one).
+    public func refineState(id: String, from expected: AgentState, to refined: AgentState, since: Date) {
+        guard var session = byID[id], session.state == expected, session.stateSince == since else { return }
+        session.state = refined
+        byID[id] = session
+    }
+
     /// Applies an event, creating or updating the matching session.
     /// Returns the updated session, or `nil` if the event maps to no state.
     @discardableResult

--- a/Sources/AgentPetCore/SessionStore.swift
+++ b/Sources/AgentPetCore/SessionStore.swift
@@ -40,6 +40,13 @@ public final class SessionStore {
         byID.removeValue(forKey: id)
     }
 
+    /// Updates the display title for a session. Called asynchronously after
+    /// transcript title resolution completes off the main thread.
+    public func updateTitle(id: String, title: String) {
+        guard byID[id] != nil else { return }
+        byID[id]?.title = title
+    }
+
     /// Applies an event, creating or updating the matching session.
     /// Returns the updated session, or `nil` if the event maps to no state.
     @discardableResult
@@ -53,6 +60,7 @@ public final class SessionStore {
         guard let state = StateMapper.state(for: event.agentKind, eventName: event.eventName) else {
             return nil
         }
+
         if var existing = byID[event.sessionId] {
             if existing.state != state { existing.stateSince = now }
             existing.state = state

--- a/Sources/AgentPetCore/StateMapper.swift
+++ b/Sources/AgentPetCore/StateMapper.swift
@@ -27,7 +27,11 @@ public enum StateMapper {
             case "SessionStart": return .registered
             case "UserPromptSubmit", "PreToolUse", "PostToolUse": return .working
             case "Notification": return .waiting
-            case "Stop", "SubagentStop": return .done
+            case "Stop": return .done
+            // SubagentStop fires when a Task() subagent finishes mid-session —
+            // not when the main session is done. Ignoring it (nil = "no state
+            // change") avoids a false done→working flicker.
+            case "SubagentStop": return nil
             default: return nil
             }
         case .codex:

--- a/Sources/AgentPetCore/TickerFormatter.swift
+++ b/Sources/AgentPetCore/TickerFormatter.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Pure formatting and sorting logic for the desktop-pet ticker.
+/// Lives in AgentPetCore so it can be unit-tested without AppKit.
+public enum TickerFormatter {
+
+    /// Short display label for an agent kind.
+    public static func agentLabel(for kind: AgentKind) -> String {
+        switch kind {
+        case .claude:    return "Claude"
+        case .cursor:    return "Cursor"
+        case .codex:     return "Codex"
+        case .gemini:    return "Gemini"
+        case .opencode:  return "Opencode"
+        case .windsurf:  return "Windsurf"
+        case .antigravity: return "Antigravity"
+        case .cli:       return "Agent"
+        case .unknown:   return "Agent"
+        }
+    }
+
+    /// One ticker line for a single session.
+    /// Format: `<AgentLabel> [<project>] → <message>`
+    public static func line(for session: AgentSession) -> String {
+        let label   = agentLabel(for: session.agentKind)
+        let project = session.project.map { ($0 as NSString).lastPathComponent } ?? session.id
+        let msg: String
+        if let m = session.message, !m.trimmingCharacters(in: .whitespaces).isEmpty {
+            msg = m
+        } else {
+            msg = session.state.rawValue.capitalized
+        }
+        return "\(label) [\(project)] → \(msg)"
+    }
+
+    /// Sort order for the ticker: waiting first, then working (most-recently
+    /// updated first), then done. Idle and registered sessions are excluded
+    /// before calling this — the caller is responsible for filtering.
+    public static func sorted(_ sessions: [AgentSession]) -> [AgentSession] {
+        sessions.sorted { a, b in
+            let pa = priority(a.state)
+            let pb = priority(b.state)
+            if pa != pb { return pa < pb }
+            return a.updatedAt > b.updatedAt
+        }
+    }
+
+    // MARK: - Private
+
+    private static func priority(_ state: AgentState) -> Int {
+        switch state {
+        case .waiting:    return 0
+        case .working:    return 1
+        case .done:       return 2
+        case .idle:       return 3
+        case .registered: return 4
+        }
+    }
+}

--- a/Sources/AgentPetCore/TranscriptReader.swift
+++ b/Sources/AgentPetCore/TranscriptReader.swift
@@ -16,6 +16,7 @@ public enum TranscriptReader {
     // Provisional titles (first user message) are not cached: a later summary
     // event should supersede them on the next call.
     nonisolated(unsafe) private static var summaryCache: [String: String] = [:]
+    nonisolated(unsafe) private static var recapCache: [String: String] = [:]
 
     /// Returns the title for the transcript at `path`, or `nil` if unreadable.
     public static func title(at path: String) -> String? {
@@ -25,9 +26,19 @@ public enum TranscriptReader {
         return result
     }
 
+    /// Returns the latest Claude assistant recap from the transcript, collapsed
+    /// to one display line, or `nil` when the transcript has no recap marker.
+    public static func latestAssistantRecap(at path: String) -> String? {
+        if let hit = recapCache[path] { return hit }
+        guard let result = readLatestAssistantRecap(path) else { return nil }
+        recapCache[path] = result
+        return result
+    }
+
     /// Clears cached titles — useful after fixing the extraction logic at runtime.
     public static func clearCache() {
         summaryCache.removeAll()
+        recapCache.removeAll()
     }
 
     /// Constructs the expected transcript path for a Claude Code session.
@@ -86,6 +97,31 @@ public enum TranscriptReader {
         return firstUserText.map { ($0, false) }
     }
 
+    private static func readLatestAssistantRecap(_ path: String) -> String? {
+        guard let handle = FileHandle(forReadingAtPath: path) else { return nil }
+        defer { try? handle.close() }
+
+        let fileSize = (try? handle.seekToEnd()) ?? 0
+        let maxBytes: UInt64 = 131_072
+        try? handle.seek(toOffset: fileSize > maxBytes ? fileSize - maxBytes : 0)
+        let raw = handle.readDataToEndOfFile()
+        guard let text = String(data: raw, encoding: .utf8) else { return nil }
+
+        for line in text.components(separatedBy: "\n").reversed() {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty,
+                  let lineData = trimmed.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                  json["type"] as? String == "assistant",
+                  let assistantText = extractAssistantText(from: json),
+                  let recap = cleanRecap(assistantText)
+            else { continue }
+            return recap
+        }
+
+        return nil
+    }
+
     private static func extractUserText(from json: [String: Any]) -> String? {
         guard let message = json["message"] as? [String: Any] else { return nil }
 
@@ -106,6 +142,46 @@ public enum TranscriptReader {
         }
 
         return nil
+    }
+
+    private static func extractAssistantText(from json: [String: Any]) -> String? {
+        guard let message = json["message"] as? [String: Any] else { return nil }
+
+        if let blocks = message["content"] as? [[String: Any]] {
+            let text = blocks.compactMap { block -> String? in
+                guard block["type"] as? String == "text" else { return nil }
+                return block["text"] as? String
+            }.joined(separator: "\n")
+            return text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : text
+        }
+
+        if let raw = message["content"] as? String {
+            return raw
+        }
+
+        return nil
+    }
+
+    private static func cleanRecap(_ text: String) -> String? {
+        let collapsed = text
+            .replacingOccurrences(of: "\r", with: "\n")
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+
+        let markers = [
+            #"(?i)(?:^|\s)(?:[※*#\-\s]*)recap\s*:\s*"#,
+            #"(?i)(?:^|\s)(?:all\s+changes\s+done|done)\.?\s+summary(?:\s+of\s+all\s+changes)?\s*:\s*"#,
+            #"(?i)(?:^|\s)summary\s+of\s+all\s+changes\s*:\s*"#
+        ]
+
+        guard let range = markers.compactMap({
+            collapsed.range(of: $0, options: .regularExpression)
+        }).first else { return nil }
+
+        let recap = collapsed[range.upperBound...]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return recap.isEmpty ? nil : String(recap)
     }
 
     /// Returns `text` trimmed and capped at 60 chars, or `nil` if it looks like

--- a/Sources/AgentPetCore/TranscriptReader.swift
+++ b/Sources/AgentPetCore/TranscriptReader.swift
@@ -35,6 +35,35 @@ public enum TranscriptReader {
         return result
     }
 
+    /// Returns the raw, trimmed text of the most recent Claude assistant
+    /// message in the transcript (capped at 400 characters), or `nil` if none
+    /// is found. Unlike `latestAssistantRecap`, this returns ordinary
+    /// turn-ending text too — it's used to check whether Claude ended its
+    /// turn by asking the user a question, not to extract a named recap.
+    public static func latestAssistantText(at path: String) -> String? {
+        guard let handle = FileHandle(forReadingAtPath: path) else { return nil }
+        defer { try? handle.close() }
+
+        let fileSize = (try? handle.seekToEnd()) ?? 0
+        let maxBytes: UInt64 = 131_072
+        try? handle.seek(toOffset: fileSize > maxBytes ? fileSize - maxBytes : 0)
+        let raw = handle.readDataToEndOfFile()
+        guard let text = String(data: raw, encoding: .utf8) else { return nil }
+
+        for line in text.components(separatedBy: "\n").reversed() {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty,
+                  let lineData = trimmed.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                  json["type"] as? String == "assistant",
+                  let assistantText = extractAssistantText(from: json)
+            else { continue }
+            return String(assistantText.trimmingCharacters(in: .whitespacesAndNewlines).prefix(400))
+        }
+
+        return nil
+    }
+
     /// Clears cached titles — useful after fixing the extraction logic at runtime.
     public static func clearCache() {
         summaryCache.removeAll()

--- a/Sources/AgentPetCore/TranscriptReader.swift
+++ b/Sources/AgentPetCore/TranscriptReader.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+/// Extracts a human-readable conversation title from an agent transcript file.
+///
+/// For Claude Code the transcript is a JSONL file. Each line is a JSON object.
+/// The reader looks for:
+/// 1. A `{"type":"summary","summary":"..."}` event — Claude names conversations
+///    with this after the first exchange.
+/// 2. Fallback: the first `{"type":"user","message":{"content":[{"type":"text","text":"..."}]}}`
+///    line, truncated to 60 characters.
+///
+/// Results are cached per path so repeated calls within the same run are free.
+public enum TranscriptReader {
+
+    // Summary-based titles are final — once cached, never re-read.
+    // Provisional titles (first user message) are not cached: a later summary
+    // event should supersede them on the next call.
+    nonisolated(unsafe) private static var summaryCache: [String: String] = [:]
+
+    /// Returns the title for the transcript at `path`, or `nil` if unreadable.
+    public static func title(at path: String) -> String? {
+        if let hit = summaryCache[path] { return hit }
+        guard let (result, isSummary) = read(path) else { return nil }
+        if isSummary { summaryCache[path] = result }
+        return result
+    }
+
+    /// Clears cached titles — useful after fixing the extraction logic at runtime.
+    public static func clearCache() {
+        summaryCache.removeAll()
+    }
+
+    /// Constructs the expected transcript path for a Claude Code session.
+    ///
+    /// Claude Code stores transcripts at `~/.claude/projects/<sanitized-cwd>/<session-id>.jsonl`
+    /// where the sanitized CWD replaces every `/` with `-` and prepends a leading `-`.
+    /// Use this when `transcript_path` is absent from the hook payload.
+    public static func inferredPath(sessionId: String, cwd: String) -> String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        // The leading '/' in an absolute path becomes the leading '-' after replacement,
+        // so no extra prefix is needed. e.g. /Users/foo → -Users-foo
+        let sanitized = cwd.replacingOccurrences(of: "/", with: "-")
+        return "\(home)/.claude/projects/\(sanitized)/\(sessionId).jsonl"
+    }
+
+    // Returns (title, isSummary) — isSummary true means the title came from a
+    // Claude-generated summary event and can be cached permanently.
+    private static func read(_ path: String) -> (String, Bool)? {
+        guard let handle = FileHandle(forReadingAtPath: path) else { return nil }
+        defer { try? handle.close() }
+        // Read first 32 KB — enough to cover the summary event which appears early.
+        let raw = handle.readData(ofLength: 32_768)
+        // Truncate to the last newline to avoid splitting a multi-byte UTF-8 sequence
+        // at the read boundary, which would make String(data:encoding:) return nil.
+        let safeRaw: Data
+        if raw.count == 32_768, let nl = raw.lastIndex(of: UInt8(ascii: "\n")) {
+            safeRaw = raw[...nl]
+        } else {
+            safeRaw = raw
+        }
+        guard let text = String(data: safeRaw, encoding: .utf8) else { return nil }
+
+        var firstUserText: String?
+
+        for line in text.components(separatedBy: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty,
+                  let lineData = trimmed.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                  let type = json["type"] as? String
+            else { continue }
+
+            // Claude Code writes a "summary" event when it names the conversation.
+            if type == "summary",
+               let summary = json["summary"] as? String,
+               !summary.trimmingCharacters(in: .whitespaces).isEmpty {
+                return (summary, true)
+            }
+
+            // Scan every user event; keep the first that yields real human text.
+            if firstUserText == nil, type == "user" {
+                firstUserText = extractUserText(from: json)
+            }
+        }
+
+        return firstUserText.map { ($0, false) }
+    }
+
+    private static func extractUserText(from json: [String: Any]) -> String? {
+        guard let message = json["message"] as? [String: Any] else { return nil }
+
+        // Array-of-blocks format (tool results, text blocks, etc.)
+        if let blocks = message["content"] as? [[String: Any]] {
+            for block in blocks {
+                // Only plain text blocks — skip tool_result, tool_use, image, etc.
+                guard block["type"] as? String == "text",
+                      let raw = block["text"] as? String else { continue }
+                if let clean = humanReadable(raw) { return clean }
+            }
+            return nil
+        }
+
+        // Plain-string format (common in older / simple sessions).
+        if let raw = message["content"] as? String {
+            return humanReadable(raw)
+        }
+
+        return nil
+    }
+
+    /// Returns `text` trimmed and capped at 60 chars, or `nil` if it looks like
+    /// a system injection (XML tags such as `<local-command>`, tool wrappers, etc.)
+    private static func humanReadable(_ text: String) -> String? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        // Skip XML-style system injections ("<local-command>…", "<result>…", etc.)
+        guard !trimmed.hasPrefix("<") else { return nil }
+        return String(trimmed.prefix(60))
+    }
+}

--- a/Sources/App/AgentIcons.swift
+++ b/Sources/App/AgentIcons.swift
@@ -1,0 +1,215 @@
+import AppKit
+import SwiftUI
+import AgentPetCore
+
+/// Renders the real brand logo for each agent kind as an NSImage from embedded
+/// SVG data. No external dependency or resource bundle — the SVG strings are
+/// compiled into the binary. Falls back to an SF Symbol for unknown kinds.
+///
+/// `NSImage(data:)` does not recognise SVG from raw bytes; macOS needs a `.svg`
+/// file URL to select the SVG renderer. Each icon is written to a temp file once
+/// and cached in memory for all subsequent calls.
+enum AgentIcons {
+
+    // Cache is MainActor-isolated: all call sites are SwiftUI views on the main actor.
+    @MainActor private static var cache: [AgentKind: NSImage] = [:]
+
+    @MainActor
+    static func image(for kind: AgentKind) -> NSImage? {
+        if let hit = cache[kind] { return hit }
+        guard let svg = svgString(for: kind),
+              let data = svg.data(using: .utf8) else { return nil }
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("agentpet-icon-\(kind.rawValue).svg")
+        // Write and read are separate: a write failure must not fall through to
+        // reading a stale file left by a previous run for a different kind.
+        do { try data.write(to: url) } catch { return nil }
+        guard let img = NSImage(contentsOf: url) else { return nil }
+        cache[kind] = img
+        return img
+    }
+
+    /// Pre-renders all brand SVG icons at launch so the first render frame is never blocked.
+    @MainActor
+    static func prewarm() {
+        for kind in brandKinds { _ = image(for: kind) }
+    }
+
+    private static func svgString(for kind: AgentKind) -> String? {
+        switch kind {
+        case .claude:    return anthropicSVG
+        case .cursor:    return cursorSVG
+        case .codex:     return openaiSVG
+        case .gemini:    return geminiSVG
+        case .windsurf:  return windsurfSVG
+        case .opencode:  return opencodeSVG
+        case .antigravity, .cli, .unknown: return nil
+        }
+    }
+
+    // MARK: - Embedded SVG strings (sourced from thesvg.org CDN, MIT codebase)
+
+    /// Anthropic "A" wordmark — mono variant, 24×24 viewBox.
+    private static let anthropicSVG = """
+    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <path fill="#CC785C" d="M17.3041 3.541h-3.6718l6.696 16.918H24Zm-10.6082 \
+    0L0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5528h3.7442L10.5363 \
+    3.5409Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z"/>
+    </svg>
+    """
+
+    /// Cursor hexagonal logo — mono variant, 24×24 viewBox.
+    private static let cursorSVG = """
+    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <path fill="#1A65E0" d="M11.503.131 1.891 5.678a.84.84 0 0 0-.42.726v11.188\
+    c0 .3.162.575.42.724l9.609 5.55a1 1 0 0 0 .998 0l9.61-5.55a.84.84 0 0 0 \
+    .42-.724V6.404a.84.84 0 0 0-.42-.726L12.497.131a1.01 1.01 0 0 0-.996 0M2.657 \
+    6.338h18.55c.263 0 .43.287.297.515L12.23 22.918c-.062.107-.229.064-.229-.06V\
+    12.335a.59.59 0 0 0-.295-.51l-9.11-5.257c-.109-.063-.064-.23.061-.23"/>
+    </svg>
+    """
+
+    /// OpenAI gear logo — default variant, coloured green (Codex brand).
+    private static let openaiSVG = """
+    <svg viewBox="0 0 256 260" xmlns="http://www.w3.org/2000/svg">
+      <path fill="#10A37F" d="M239.184 106.203a64.716 64.716 0 0 0-5.576-53.103C219.452 \
+    28.459 191 15.784 163.213 21.74A65.586 65.586 0 0 0 52.096 45.22a64.716 64.716 \
+    0 0 0-43.23 31.36c-14.31 24.602-11.061 55.634 8.033 76.74a64.665 64.665 0 0 0 \
+    5.525 53.102c14.174 24.65 42.644 37.324 70.446 31.36a64.72 64.72 0 0 0 48.754 \
+    21.744c28.481.025 53.714-18.361 62.414-45.481a64.767 64.767 0 0 0 43.229-31.36\
+    c14.137-24.558 10.875-55.423-8.083-76.483Zm-97.56 136.338a48.397 48.397 0 0 \
+    1-31.105-11.255l1.535-.87 51.67-29.825a8.595 8.595 0 0 0 4.247-7.367v-72.85\
+    l21.845 12.636c.218.111.37.32.409.563v60.367c-.056 26.818-21.783 48.545-48.601 \
+    48.601Zm-104.466-44.61a48.345 48.345 0 0 1-5.781-32.589l1.534.921 51.722 29.826\
+    a8.339 8.339 0 0 0 8.441 0l63.181-36.425v25.221a.87.87 0 0 1-.358.665l-52.335 \
+    30.184c-23.257 13.398-52.97 5.431-66.404-17.803ZM23.549 85.38a48.499 48.499 0 \
+    0 1 25.58-21.333v61.39a8.288 8.288 0 0 0 4.195 7.316l62.874 36.272-21.845 \
+    12.636a.819.819 0 0 1-.767 0L41.353 151.53c-23.211-13.454-31.171-43.144-17.804\
+    -66.405v.256Zm179.466 41.695-63.08-36.63L161.73 77.86a.819.819 0 0 1 .768 \
+    0l52.233 30.184a48.6 48.6 0 0 1-7.316 87.635v-61.391a8.544 8.544 0 0 \
+    0-4.4-7.213Zm21.742-32.69-1.535-.922-51.619-30.081a8.39 8.39 0 0 0-8.492 \
+    0L99.98 99.808V74.587a.716.716 0 0 1 .307-.665l52.233-30.133a48.652 48.652 \
+    0 0 1 72.236 50.391v.205ZM88.061 139.097l-21.845-12.585a.87.87 0 0 \
+    1-.41-.614V65.685a48.652 48.652 0 0 1 79.757-37.346l-1.535.87-51.67 \
+    29.825a8.595 8.595 0 0 0-4.246 7.367l-.051 72.697Zm11.868-25.58 28.138-16.217\
+     28.188 16.218v32.434l-28.086 16.218-28.188-16.218-.052-32.434Z"/>
+    </svg>
+    """
+
+    /// Gemini 4-pointed star shape extracted from the official logo mask.
+    private static let geminiSVG = """
+    <svg viewBox="0 0 296 298" xmlns="http://www.w3.org/2000/svg">
+      <path fill="#4285F4" d="M141.201 4.886c2.282-6.17 11.042-6.071 13.184.148\
+    l5.985 17.37a184.004 184.004 0 0 0 111.257 113.049l19.304 6.997c6.143 2.227 \
+    6.156 10.91.02 13.155l-19.35 7.082a184.001 184.001 0 0 0-109.495 109.385\
+    l-7.573 20.629c-2.241 6.105-10.869 6.121-13.133.025l-7.908-21.296a184 184 \
+    0 0 0-109.02-108.658l-19.698-7.239c-6.102-2.243-6.118-10.867-.025-13.132\
+    l20.083-7.467A183.998 183.998 0 0 0 133.291 26.28l7.91-21.394Z"/>
+    </svg>
+    """
+
+    /// Windsurf "N" logo — mono variant, 24×24 viewBox.
+    private static let windsurfSVG = """
+    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <path fill="#06B6D4" d="M23.55 5.067c-1.2038-.002-2.1806.973-2.1806 \
+    2.1765v4.8676c0 .972-.8035 1.7594-1.7597 1.7594-.568 0-1.1352-.286-1.4718\
+    -.7659l-4.9713-7.1003c-.4125-.5896-1.0837-.941-1.8103-.941-1.1334 0-2.1533\
+    .9635-2.1533 2.153v4.8957c0 .972-.7969 1.7594-1.7596 1.7594-.57 0-1.1363\
+    -.286-1.4728-.7658L.4076 5.1598C.2822 4.9798 0 5.0688 0 5.2882v4.2452c0 \
+    .2147.0656.4228.1884.599l5.4748 7.8183c.3234.462.8006.8052 1.3509.9298\
+    1.3771.313 2.6446-.747 2.6446-2.0977v-4.893c0-.972.7875-1.7593 1.7596\
+    -1.7593h.003a1.798 1.798 0 0 1 1.4718.7658l4.9723 7.0994c.4135.5905 1.05\
+    .941 1.8093.941 1.1587 0 2.1515-.9645 2.1515-2.153v-4.8948c0-.972.7875\
+    -1.7594 1.7596-1.7594h.194a.22.22 0 0 0 .2204-.2202v-4.622a.22.22 0 0 \
+    0-.2203-.2203Z"/>
+    </svg>
+    """
+
+    /// Opencode bracket logo — mono variant, 24×24 viewBox.
+    private static let opencodeSVG = """
+    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <path fill="#F97316" fill-rule="evenodd" d="M16 6H8v12h8V6zm4 16H4V2h16v20z"/>
+    </svg>
+    """
+}
+
+// MARK: - SwiftUI view
+
+/// Shows the brand logo for the agent kind; thin wrapper over `ResolvedIconView`.
+struct AgentIconView: View {
+    let kind: AgentKind
+    var size: CGFloat = 14
+
+    var body: some View {
+        ResolvedIconView(choice: .brandLogo(kind), size: size)
+    }
+}
+
+// MARK: - AgentKind identifiable (needed for popover(item:))
+
+extension AgentKind: Identifiable {
+    public var id: String { rawValue }
+}
+
+// MARK: - Curated SF Symbols for the icon picker
+
+extension AgentIcons {
+    /// All AgentKind cases that have embedded SVG brand logos.
+    static let brandKinds: [AgentKind] = [.claude, .cursor, .codex, .gemini, .windsurf, .opencode]
+
+    /// 28 curated SF Symbol names shown in the icon picker.
+    static let curatedSymbols: [String] = [
+        // Code & Terminal
+        "terminal", "chevron.left.forwardslash.chevron.right", "curlybraces", "cpu", "command",
+        // AI & Magic
+        "brain", "wand.and.stars", "sparkles", "bolt",
+        // Workflow
+        "arrow.triangle.2.circlepath", "checklist", "tray.and.arrow.down", "doc.text",
+        // Network
+        "antenna.radiowaves.left.and.right", "network", "wifi", "cloud",
+        // Interface
+        "gear", "slider.horizontal.3", "paintbrush", "theatermasks", "person.crop.circle",
+        // Objects
+        "desktopcomputer", "laptopcomputer", "keyboard", "hammer", "wrench.and.screwdriver",
+        // Extra
+        "eye", "hourglass",
+    ]
+}
+
+// MARK: - ResolvedIconView
+
+/// Renders an `IconChoice` — either a brand SVG logo or an SF Symbol.
+struct ResolvedIconView: View {
+    let choice: IconChoice
+    var size: CGFloat = 14
+
+    var body: some View {
+        switch choice {
+        case .brandLogo(let kind):
+            if let img = AgentIcons.image(for: kind) {
+                Image(nsImage: img)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: size, height: size)
+            } else {
+                Image(systemName: fallback(for: kind))
+                    .font(.system(size: size * 0.8, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .frame(width: size, height: size)
+            }
+        case .sfSymbol(let name):
+            Image(systemName: name)
+                .font(.system(size: size * 0.8, weight: .medium))
+                .foregroundStyle(.primary)
+                .frame(width: size, height: size)
+        }
+    }
+
+    private func fallback(for kind: AgentKind) -> String {
+        switch kind {
+        case .cli:     return "terminal"
+        case .unknown: return "questionmark.circle"
+        default:       return "sparkle"
+        }
+    }
+}

--- a/Sources/App/AgentPetApp.swift
+++ b/Sources/App/AgentPetApp.swift
@@ -14,17 +14,23 @@ struct AgentPetApp: App {
 /// Runs the app as a menu bar accessory (no Dock icon) and boots the daemon.
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
+    // Held strongly so the Sparkle updater delegate and background timers are
+    // never deallocated for the lifetime of the app.
+    private var updater: UpdaterController?
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory)
         ImagePetStore.shared.reload()
         if PetController.shared.selectedPetID == nil {
             PetController.shared.selectedPetID = ImagePetStore.shared.packs.first?.id
         }
+        AgentIcons.prewarm()
         PetController.shared.start()
         PetWindowController.shared.start()
         AppDaemon.shared.start()
         SettingsModel.shared.migrateInstalledHooksIfNeeded()
-        _ = UpdaterController.shared
+        SettingsModel.shared.repairStaleHookPathsIfNeeded()
+        updater = UpdaterController.shared
         StatusBarController.shared.start()
         DefaultPetBootstrap.installIfNeeded()
         SettingsWindowController.shared.showOnFirstLaunch()

--- a/Sources/App/AppDaemon.swift
+++ b/Sources/App/AppDaemon.swift
@@ -53,11 +53,49 @@ final class AppDaemon: ObservableObject {
 
     private func ingest(_ event: AgentEvent) {
         let before = store.session(id: event.sessionId)?.state
-        if let updated = store.apply(event, now: Date()) {
+        guard let updated = store.apply(event, now: Date()) else {
+            refresh()
+            return
+        }
+        resolveTitle(for: event)
+
+        // Claude's Stop hook fires identically whether the agent is truly
+        // done or just ended its turn by asking the user a question — hold
+        // the notification until an async transcript check resolves, so we
+        // fire exactly one notification reflecting the true final state.
+        if event.agentKind == .claude, event.eventName == "Stop", updated.state == .done {
+            refineDoneIfQuestion(event: event, before: before, session: updated)
+        } else {
             notifyIfNeeded(before: before, session: updated)
-            resolveTitle(for: event)
         }
         refresh()
+    }
+
+    /// Reads the transcript off-thread to check whether Claude ended its turn
+    /// by asking the user something; if so, corrects `.done` to `.waiting`.
+    /// Either way, fires the (single, final-state) notification afterwards.
+    private func refineDoneIfQuestion(event: AgentEvent, before: AgentState?, session: AgentSession) {
+        let sessionId = event.sessionId
+        let stateSince = session.stateSince
+        let path: String? = event.transcriptPath
+            ?? event.project.map { TranscriptReader.inferredPath(sessionId: sessionId, cwd: $0) }
+        guard let path else {
+            notifyIfNeeded(before: before, session: session)
+            return
+        }
+        Task.detached(priority: .utility) { [weak self] in
+            let isQuestion = TranscriptReader.latestAssistantText(at: path)
+                .map(QuestionDetector.looksLikeQuestion) ?? false
+            await MainActor.run { [weak self] in
+                guard let self else { return }
+                if isQuestion {
+                    self.store.refineState(id: sessionId, from: .done, to: .waiting, since: stateSince)
+                }
+                guard let final = self.store.session(id: sessionId) else { return }
+                self.notifyIfNeeded(before: before, session: final)
+                self.refresh()
+            }
+        }
     }
 
     private func resolveTitle(for event: AgentEvent) {

--- a/Sources/App/AppDaemon.swift
+++ b/Sources/App/AppDaemon.swift
@@ -55,8 +55,23 @@ final class AppDaemon: ObservableObject {
         let before = store.session(id: event.sessionId)?.state
         if let updated = store.apply(event, now: Date()) {
             notifyIfNeeded(before: before, session: updated)
+            resolveTitle(for: event)
         }
         refresh()
+    }
+
+    private func resolveTitle(for event: AgentEvent) {
+        let sessionId = event.sessionId
+        let path: String? = event.transcriptPath
+            ?? event.project.map { TranscriptReader.inferredPath(sessionId: sessionId, cwd: $0) }
+        guard let path else { return }
+        Task.detached(priority: .utility) { [weak self] in
+            guard let title = TranscriptReader.title(at: path) else { return }
+            await MainActor.run { [weak self] in
+                self?.store.updateTitle(id: sessionId, title: title)
+                self?.refresh()
+            }
+        }
     }
 
     private func notifyIfNeeded(before: AgentState?, session: AgentSession) {

--- a/Sources/App/BubbleSettings.swift
+++ b/Sources/App/BubbleSettings.swift
@@ -270,7 +270,7 @@ final class BubbleSettings: ObservableObject {
         minStateFilter = MinStateFilter(rawValue: ud.string(forKey: Keys.minStateFilter) ?? "") ?? .all
         groupByKind        = ud.bool(forKey: Keys.groupByKind)
         collapseDuplicates = ud.object(forKey: Keys.collapseDuplicates) as? Bool ?? false
-        multiAgentBubbleEnabled = ud.object(forKey: Keys.multiAgentBubbleEnabled) as? Bool ?? false
+        multiAgentBubbleEnabled = ud.object(forKey: Keys.multiAgentBubbleEnabled) as? Bool ?? true
         hiddenKinds        = Set((Self.loadJSON(Keys.hiddenKinds) as [String]? ?? []).compactMap(AgentKind.init(rawValue:)))
         iconChoices    = Self.loadJSON(Keys.iconChoices) ?? [:]
     }

--- a/Sources/App/BubbleSettings.swift
+++ b/Sources/App/BubbleSettings.swift
@@ -269,7 +269,10 @@ final class BubbleSettings: ObservableObject {
     /// When enabled, active sessions render with the structured multi-agent
     /// bubble. When off, AgentPet keeps the default chat bubble behavior.
     @Published var multiAgentBubbleEnabled: Bool {
-        didSet { ud.set(multiAgentBubbleEnabled, forKey: Keys.multiAgentBubbleEnabled) }
+        didSet {
+            ud.set(multiAgentBubbleEnabled, forKey: Keys.multiAgentBubbleEnabled)
+            PetController.shared.applyBubbleModeChange()
+        }
     }
     @Published var hiddenKinds: Set<AgentKind> {
         didSet { saveJSON(Keys.hiddenKinds, Array(hiddenKinds).map(\.rawValue)) }

--- a/Sources/App/BubbleSettings.swift
+++ b/Sources/App/BubbleSettings.swift
@@ -1,0 +1,286 @@
+import Foundation
+import SwiftUI
+import AgentPetCore
+
+// MARK: - Token types
+
+enum BubbleToken: String, CaseIterable, Codable, Identifiable {
+    case dot, icon, title, project, separator, message, stateLabel, elapsed
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .dot:        return "State dot"
+        case .icon:       return "Agent icon"
+        case .title:      return "Chat title"
+        case .project:    return "Project folder"
+        case .separator:  return "Separator"
+        case .message:    return "Activity message"
+        case .stateLabel: return "State label"
+        case .elapsed:    return "Elapsed time"
+        }
+    }
+
+    var shortName: String {
+        switch self {
+        case .dot:        return "Dot"
+        case .icon:       return "Icon"
+        case .title:      return "Title"
+        case .project:    return "Project"
+        case .separator:  return "Sep"
+        case .message:    return "Message"
+        case .stateLabel: return "State"
+        case .elapsed:    return "Elapsed"
+        }
+    }
+
+    var chipSymbol: String {
+        switch self {
+        case .dot:        return "circle.fill"
+        case .icon:       return "sparkle"
+        case .title:      return "text.quote"
+        case .project:    return "folder.fill"
+        case .separator:  return "arrow.right"
+        case .message:    return "bubble.left.fill"
+        case .stateLabel: return "tag.fill"
+        case .elapsed:    return "clock.fill"
+        }
+    }
+
+    var chipColor: Color {
+        switch self {
+        case .dot:        return .orange
+        case .icon:       return .purple
+        case .title:      return .blue
+        case .project:    return .green
+        case .separator:  return .gray
+        case .message:    return .indigo
+        case .stateLabel: return .yellow
+        case .elapsed:    return .teal
+        }
+    }
+}
+
+struct BubbleTokenItem: Codable, Identifiable, Equatable {
+    var id: String { token.rawValue }
+    let token: BubbleToken
+    var isVisible: Bool
+}
+
+struct BubbleLayout: Codable, Equatable {
+    var tokens: [BubbleTokenItem]
+
+    static let original = BubbleLayout(tokens: [
+        .init(token: .dot,        isVisible: true),
+        .init(token: .icon,       isVisible: true),
+        .init(token: .project,    isVisible: true),
+        .init(token: .separator,  isVisible: true),
+        .init(token: .message,    isVisible: true),
+        .init(token: .title,      isVisible: false),
+        .init(token: .stateLabel, isVisible: false),
+        .init(token: .elapsed,    isVisible: false),
+    ])
+
+    static let standard = BubbleLayout(tokens: [
+        .init(token: .dot,        isVisible: true),
+        .init(token: .icon,       isVisible: true),
+        .init(token: .title,      isVisible: true),
+        .init(token: .project,    isVisible: true),
+        .init(token: .separator,  isVisible: true),
+        .init(token: .message,    isVisible: true),
+        .init(token: .stateLabel, isVisible: false),
+        .init(token: .elapsed,    isVisible: false),
+    ])
+
+    static let detailed = BubbleLayout(tokens: [
+        .init(token: .dot,        isVisible: true),
+        .init(token: .icon,       isVisible: true),
+        .init(token: .title,      isVisible: true),
+        .init(token: .project,    isVisible: true),
+        .init(token: .separator,  isVisible: true),
+        .init(token: .message,    isVisible: true),
+        .init(token: .stateLabel, isVisible: true),
+        .init(token: .elapsed,    isVisible: true),
+    ])
+
+}
+
+// MARK: - Icon choice
+
+enum IconChoice: Equatable {
+    case brandLogo(AgentKind)
+    case sfSymbol(String)
+}
+
+extension IconChoice: Codable {
+    private enum CodingKeys: String, CodingKey { case type, value }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try c.decode(String.self, forKey: .type)
+        let value = try c.decode(String.self, forKey: .value)
+        switch type {
+        case "brandLogo": self = .brandLogo(AgentKind(rawValue: value) ?? .unknown)
+        default:          self = .sfSymbol(value)
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .brandLogo(let k):
+            try c.encode("brandLogo", forKey: .type)
+            try c.encode(k.rawValue, forKey: .value)
+        case .sfSymbol(let n):
+            try c.encode("sfSymbol", forKey: .type)
+            try c.encode(n, forKey: .value)
+        }
+    }
+}
+
+// MARK: - Min-state filter
+
+enum MinStateFilter: String, CaseIterable, Codable {
+    case all, doneAndAbove, workingAndWaiting, workingOnly
+
+    var displayName: String {
+        switch self {
+        case .all:               return "All states"
+        case .doneAndAbove:      return "Done and above"
+        case .workingAndWaiting: return "Working & Waiting"
+        case .workingOnly:       return "Working only"
+        }
+    }
+
+    func includes(_ state: AgentState) -> Bool {
+        // attentionPriority is internal to AgentPetCore — compare states explicitly
+        switch self {
+        case .all:               return true
+        case .doneAndAbove:      return state == .working || state == .waiting || state == .done
+        case .workingAndWaiting: return state == .working || state == .waiting
+        case .workingOnly:       return state == .working
+        }
+    }
+}
+
+// MARK: - BubbleSettings
+
+@MainActor
+final class BubbleSettings: ObservableObject {
+    static let shared = BubbleSettings()
+
+    enum FontSize: String, CaseIterable, Codable {
+        case small, medium, large
+        var primaryPt: CGFloat   { switch self { case .small: 10; case .medium: 12; case .large: 14 } }
+        var secondaryPt: CGFloat { switch self { case .small: 9;  case .medium: 10.5; case .large: 12 } }
+        var iconPt: CGFloat      { primaryPt + 2 }
+    }
+
+    enum Theme: String, CaseIterable, Codable {
+        case light, dark, system
+        var displayName: String { rawValue.capitalized }
+    }
+
+    // MARK: Published properties
+
+    @Published var customLayout: BubbleLayout {
+        didSet { saveJSON(Keys.customLayout, customLayout) }
+    }
+    @Published var separatorChar: String {
+        didSet { ud.set(separatorChar, forKey: Keys.separatorChar) }
+    }
+    @Published var fontSize: FontSize {
+        didSet { ud.set(fontSize.rawValue, forKey: Keys.fontSize) }
+    }
+    @Published var opacity: Double {
+        didSet { ud.set(opacity, forKey: Keys.opacity) }
+    }
+    @Published var theme: Theme {
+        didSet { ud.set(theme.rawValue, forKey: Keys.theme) }
+    }
+    @Published var maxSessions: Int {
+        didSet { ud.set(maxSessions, forKey: Keys.maxSessions) }
+    }
+    @Published var minStateFilter: MinStateFilter {
+        didSet { ud.set(minStateFilter.rawValue, forKey: Keys.minStateFilter) }
+    }
+    @Published var groupByKind: Bool {
+        didSet { ud.set(groupByKind, forKey: Keys.groupByKind) }
+    }
+    /// When true, rows with the same session id are collapsed into one row with
+    /// a ×N badge (normally one row per session; leave off for separate sessions).
+    @Published var collapseDuplicates: Bool {
+        didSet { ud.set(collapseDuplicates, forKey: Keys.collapseDuplicates) }
+    }
+    /// When enabled, active sessions render with the structured multi-agent
+    /// bubble. When off, AgentPet keeps the default chat bubble behavior.
+    @Published var multiAgentBubbleEnabled: Bool {
+        didSet { ud.set(multiAgentBubbleEnabled, forKey: Keys.multiAgentBubbleEnabled) }
+    }
+    @Published var hiddenKinds: Set<AgentKind> {
+        didSet { saveJSON(Keys.hiddenKinds, Array(hiddenKinds).map(\.rawValue)) }
+    }
+    /// Keyed by AgentKind.rawValue for JSON compatibility.
+    @Published var iconChoices: [String: IconChoice] {
+        didSet { saveJSON(Keys.iconChoices, iconChoices) }
+    }
+
+    // MARK: Computed
+
+    var effectiveLayout: BubbleLayout { customLayout }
+
+    func iconChoice(for kind: AgentKind) -> IconChoice {
+        iconChoices[kind.rawValue] ?? .brandLogo(kind)
+    }
+
+    func setIconChoice(_ choice: IconChoice, for kind: AgentKind) {
+        iconChoices[kind.rawValue] = choice
+    }
+
+    func resetIconChoice(for kind: AgentKind) {
+        iconChoices.removeValue(forKey: kind.rawValue)
+    }
+
+    // MARK: Private
+
+    private let ud = UserDefaults.standard
+
+    private enum Keys {
+        static let customLayout    = "agentpet.bubble.customLayout"
+        static let separatorChar   = "agentpet.bubble.separatorChar"
+        static let fontSize        = "agentpet.bubble.fontSize"
+        static let opacity         = "agentpet.bubble.opacity"
+        static let theme           = "agentpet.bubble.theme"
+        static let maxSessions     = "agentpet.bubble.maxSessions"
+        static let minStateFilter  = "agentpet.bubble.minStateFilter"
+        static let groupByKind         = "agentpet.bubble.groupByKind"
+        static let collapseDuplicates  = "agentpet.bubble.collapseDuplicates"
+        static let multiAgentBubbleEnabled = "agentpet.bubble.multiAgentBubbleEnabled"
+        static let hiddenKinds         = "agentpet.bubble.hiddenKinds"
+        static let iconChoices     = "agentpet.bubble.iconChoices"
+    }
+
+    init() {
+        customLayout   = Self.loadJSON(Keys.customLayout) ?? .original
+        separatorChar  = ud.string(forKey: Keys.separatorChar) ?? "·"
+        fontSize       = FontSize(rawValue: ud.string(forKey: Keys.fontSize) ?? "") ?? .medium
+        opacity        = ud.object(forKey: Keys.opacity) as? Double ?? 1.0
+        theme          = Theme(rawValue: ud.string(forKey: Keys.theme) ?? "") ?? .system
+        maxSessions    = ud.object(forKey: Keys.maxSessions) as? Int ?? 5
+        minStateFilter = MinStateFilter(rawValue: ud.string(forKey: Keys.minStateFilter) ?? "") ?? .all
+        groupByKind        = ud.bool(forKey: Keys.groupByKind)
+        collapseDuplicates = ud.object(forKey: Keys.collapseDuplicates) as? Bool ?? false
+        multiAgentBubbleEnabled = ud.object(forKey: Keys.multiAgentBubbleEnabled) as? Bool ?? false
+        hiddenKinds        = Set((Self.loadJSON(Keys.hiddenKinds) as [String]? ?? []).compactMap(AgentKind.init(rawValue:)))
+        iconChoices    = Self.loadJSON(Keys.iconChoices) ?? [:]
+    }
+
+    private func saveJSON<T: Encodable>(_ key: String, _ value: T) {
+        ud.set(try? JSONEncoder().encode(value), forKey: key)
+    }
+
+    private static func loadJSON<T: Decodable>(_ key: String) -> T? {
+        guard let data = UserDefaults.standard.data(forKey: key) else { return nil }
+        return try? JSONDecoder().decode(T.self, from: data)
+    }
+}

--- a/Sources/App/BubbleSettings.swift
+++ b/Sources/App/BubbleSettings.swift
@@ -224,6 +224,12 @@ final class BubbleSettings: ObservableObject {
     @Published var iconChoices: [String: IconChoice] {
         didSet { saveJSON(Keys.iconChoices, iconChoices) }
     }
+    @Published var activityTheme: ActivityTheme {
+        didSet {
+            ud.set(activityTheme.rawValue, forKey: Keys.activityTheme)
+            ClaudeActivityFormatter.currentTheme = activityTheme
+        }
+    }
 
     // MARK: Computed
 
@@ -258,6 +264,7 @@ final class BubbleSettings: ObservableObject {
         static let multiAgentBubbleEnabled = "agentpet.bubble.multiAgentBubbleEnabled"
         static let hiddenKinds         = "agentpet.bubble.hiddenKinds"
         static let iconChoices     = "agentpet.bubble.iconChoices"
+        static let activityTheme   = "agentpet.bubble.activityTheme"
     }
 
     init() {
@@ -273,6 +280,8 @@ final class BubbleSettings: ObservableObject {
         multiAgentBubbleEnabled = ud.object(forKey: Keys.multiAgentBubbleEnabled) as? Bool ?? true
         hiddenKinds        = Set((Self.loadJSON(Keys.hiddenKinds) as [String]? ?? []).compactMap(AgentKind.init(rawValue:)))
         iconChoices    = Self.loadJSON(Keys.iconChoices) ?? [:]
+        activityTheme  = ActivityTheme(rawValue: ud.string(forKey: Keys.activityTheme) ?? "") ?? .chef
+        ClaudeActivityFormatter.currentTheme = activityTheme
     }
 
     private func saveJSON<T: Encodable>(_ key: String, _ value: T) {

--- a/Sources/App/BubbleSettings.swift
+++ b/Sources/App/BubbleSettings.swift
@@ -138,6 +138,58 @@ extension IconChoice: Codable {
     }
 }
 
+// MARK: - Session grouping
+
+/// Whether the bubble shows one row per agent kind or one row per session.
+enum BubbleSessionGrouping: String, CaseIterable, Codable {
+    /// Collapse sessions sharing an agent kind into one row with a ×N badge.
+    case byKind
+    /// Every active session gets its own row.
+    case allSessions
+
+    var displayName: String {
+        switch self {
+        case .byKind:      return "Grouped by agent"
+        case .allSessions: return "All sessions"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .byKind:      return "One row per agent kind (×N when multiple)"
+        case .allSessions: return "One row per session"
+        }
+    }
+}
+
+// MARK: - Display mode
+
+/// How the multi-agent bubble lays out rows when more than one agent is active.
+enum BubbleDisplayMode: String, CaseIterable, Codable {
+    /// All rows up to `maxSessions`.
+    case list
+    /// One row at a time, cycling every 3 s with dot indicators (fixed height).
+    case carousel
+    /// Summary header, first two rows, fold for overflow.
+    case compact
+
+    var displayName: String {
+        switch self {
+        case .list:     return "All rows"
+        case .carousel: return "Carousel"
+        case .compact:  return "Compact"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .list:     return "Show every row at once, up to the max below."
+        case .carousel: return "One row at a time. Auto-cycles every 3 s — swipe or drag to browse."
+        case .compact:  return "Summary header, first two rows, then fold the rest."
+        }
+    }
+}
+
 // MARK: - Min-state filter
 
 enum MinStateFilter: String, CaseIterable, Codable {
@@ -204,13 +256,15 @@ final class BubbleSettings: ObservableObject {
     @Published var minStateFilter: MinStateFilter {
         didSet { ud.set(minStateFilter.rawValue, forKey: Keys.minStateFilter) }
     }
+    @Published var sessionGrouping: BubbleSessionGrouping {
+        didSet { ud.set(sessionGrouping.rawValue, forKey: Keys.sessionGrouping) }
+    }
+    /// When showing all sessions, sort rows by agent kind before priority.
     @Published var groupByKind: Bool {
         didSet { ud.set(groupByKind, forKey: Keys.groupByKind) }
     }
-    /// When true, rows with the same session id are collapsed into one row with
-    /// a ×N badge (normally one row per session; leave off for separate sessions).
-    @Published var collapseDuplicates: Bool {
-        didSet { ud.set(collapseDuplicates, forKey: Keys.collapseDuplicates) }
+    @Published var displayMode: BubbleDisplayMode {
+        didSet { ud.set(displayMode.rawValue, forKey: Keys.displayMode) }
     }
     /// When enabled, active sessions render with the structured multi-agent
     /// bubble. When off, AgentPet keeps the default chat bubble behavior.
@@ -259,8 +313,10 @@ final class BubbleSettings: ObservableObject {
         static let theme           = "agentpet.bubble.theme"
         static let maxSessions     = "agentpet.bubble.maxSessions"
         static let minStateFilter  = "agentpet.bubble.minStateFilter"
+        static let sessionGrouping     = "agentpet.bubble.sessionGrouping"
         static let groupByKind         = "agentpet.bubble.groupByKind"
-        static let collapseDuplicates  = "agentpet.bubble.collapseDuplicates"
+        static let collapseDuplicates  = "agentpet.bubble.collapseDuplicates" // legacy
+        static let displayMode         = "agentpet.bubble.displayMode"
         static let multiAgentBubbleEnabled = "agentpet.bubble.multiAgentBubbleEnabled"
         static let hiddenKinds         = "agentpet.bubble.hiddenKinds"
         static let iconChoices     = "agentpet.bubble.iconChoices"
@@ -275,8 +331,9 @@ final class BubbleSettings: ObservableObject {
         theme          = Theme(rawValue: ud.string(forKey: Keys.theme) ?? "") ?? .system
         maxSessions    = ud.object(forKey: Keys.maxSessions) as? Int ?? 5
         minStateFilter = MinStateFilter(rawValue: ud.string(forKey: Keys.minStateFilter) ?? "") ?? .all
-        groupByKind        = ud.bool(forKey: Keys.groupByKind)
-        collapseDuplicates = ud.object(forKey: Keys.collapseDuplicates) as? Bool ?? false
+        sessionGrouping = Self.loadSessionGrouping()
+        groupByKind     = ud.bool(forKey: Keys.groupByKind)
+        displayMode = BubbleDisplayMode(rawValue: ud.string(forKey: Keys.displayMode) ?? "") ?? .carousel
         multiAgentBubbleEnabled = ud.object(forKey: Keys.multiAgentBubbleEnabled) as? Bool ?? true
         hiddenKinds        = Set((Self.loadJSON(Keys.hiddenKinds) as [String]? ?? []).compactMap(AgentKind.init(rawValue:)))
         iconChoices    = Self.loadJSON(Keys.iconChoices) ?? [:]
@@ -291,5 +348,18 @@ final class BubbleSettings: ObservableObject {
     private static func loadJSON<T: Decodable>(_ key: String) -> T? {
         guard let data = UserDefaults.standard.data(forKey: key) else { return nil }
         return try? JSONDecoder().decode(T.self, from: data)
+    }
+
+    private static func loadSessionGrouping() -> BubbleSessionGrouping {
+        let ud = UserDefaults.standard
+        if let raw = ud.string(forKey: Keys.sessionGrouping),
+           let mode = BubbleSessionGrouping(rawValue: raw) {
+            return mode
+        }
+        // Migrate from the old collapseDuplicates toggle.
+        if ud.object(forKey: Keys.collapseDuplicates) as? Bool == false {
+            return .allSessions
+        }
+        return .byKind
     }
 }

--- a/Sources/App/BubbleSettingsView.swift
+++ b/Sources/App/BubbleSettingsView.swift
@@ -1,0 +1,569 @@
+import SwiftUI
+import AgentPetCore
+import UniformTypeIdentifiers
+
+// MARK: - BubbleSettingsView
+
+struct BubbleSettingsView: View {
+    @ObservedObject private var settings = BubbleSettings.shared
+    @State private var dragging: BubbleToken?
+    @State private var iconPickerKind: AgentKind?
+
+    var body: some View {
+        Form {
+            paletteSection
+            canvasSection
+            agentIconsSection
+            appearanceSection
+            filterSection
+        }
+        .formStyle(.grouped)
+        .popover(item: $iconPickerKind) { kind in
+            IconPickerPopover(kind: kind)
+        }
+    }
+
+    // MARK: Available tokens (palette)
+
+    private var inactiveTokens: [BubbleToken] {
+        BubbleToken.allCases.filter { token in
+            !settings.customLayout.tokens.contains { $0.token == token && $0.isVisible }
+        }
+    }
+
+    private var activeTokenItems: [BubbleTokenItem] {
+        settings.customLayout.tokens.filter { $0.isVisible }
+    }
+
+    private var paletteSection: some View {
+        Section {
+            if inactiveTokens.isEmpty {
+                Text("All tokens are active")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 4)
+            } else {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ForEach(inactiveTokens, id: \.self) { token in
+                            PaletteChip(token: token) { addToken(token) }
+                        }
+                    }
+                    .padding(.horizontal, 2)
+                    .padding(.vertical, 2)
+                }
+            }
+        } header: {
+            Text("Available tokens")
+        } footer: {
+            Text("Tap a chip to add it to the bubble layout.")
+        }
+    }
+
+    // MARK: Active canvas + preview
+
+    private var canvasSection: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 0) {
+                // Chip row
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        if activeTokenItems.isEmpty {
+                            Text("Add tokens from above")
+                                .font(.caption)
+                                .foregroundStyle(.tertiary)
+                                .frame(height: 36)
+                        } else {
+                            ForEach(activeTokenItems) { item in
+                                CanvasChip(
+                                    token: item.token,
+                                    isDragging: dragging == item.token
+                                ) {
+                                    removeToken(item.token)
+                                }
+                                .onDrag {
+                                    dragging = item.token
+                                    return NSItemProvider(object: item.token.rawValue as NSString)
+                                }
+                                .onDrop(
+                                    of: [UTType.plainText],
+                                    delegate: ChipDropDelegate(
+                                        target: item.token,
+                                        tokens: $settings.customLayout.tokens,
+                                        dragging: $dragging
+                                    )
+                                )
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 2)
+                    .padding(.vertical, 6)
+                }
+
+                Divider()
+
+                // Live preview
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Preview")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    BubbleRowPreview()
+                }
+                .padding(.vertical, 10)
+
+                Divider()
+
+                // Reset shortcuts
+                HStack(spacing: 8) {
+                    Text("Reset:")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Button("Original") { settings.customLayout = .original }
+                        .controlSize(.small)
+                    Button("Standard") { settings.customLayout = .standard }
+                        .controlSize(.small)
+                    Button("Detailed") { settings.customLayout = .detailed }
+                        .controlSize(.small)
+                    Spacer()
+                }
+                .padding(.vertical, 8)
+            }
+        } header: {
+            Text("Bubble layout")
+        } footer: {
+            Text("Drag chips to reorder · × to remove")
+        }
+    }
+
+    // MARK: Helpers
+
+    private func addToken(_ token: BubbleToken) {
+        withAnimation(.easeOut(duration: 0.18)) {
+            if let idx = settings.customLayout.tokens.firstIndex(where: { $0.token == token }) {
+                settings.customLayout.tokens[idx].isVisible = true
+            } else {
+                settings.customLayout.tokens.append(BubbleTokenItem(token: token, isVisible: true))
+            }
+        }
+    }
+
+    private func removeToken(_ token: BubbleToken) {
+        withAnimation(.easeOut(duration: 0.18)) {
+            if let idx = settings.customLayout.tokens.firstIndex(where: { $0.token == token }) {
+                settings.customLayout.tokens[idx].isVisible = false
+            }
+        }
+    }
+
+    // MARK: Agent Icons
+
+    private var agentIconsSection: some View {
+        Section("Agent Icons") {
+            ForEach(AgentCatalog.all, id: \.kind) { agent in
+                HStack(spacing: 10) {
+                    ResolvedIconView(choice: settings.iconChoice(for: agent.kind), size: 20)
+                    Text(agent.displayName)
+                    Spacer()
+                    Button("Change…") { iconPickerKind = agent.kind }
+                        .controlSize(.small)
+                }
+            }
+        }
+    }
+
+    // MARK: Appearance
+
+    private var appearanceSection: some View {
+        Section("Appearance") {
+            HStack {
+                Text("Separator")
+                Spacer()
+                Picker("Separator", selection: $settings.separatorChar) {
+                    Text("·").tag("·")
+                    Text("→").tag("→")
+                    Text("|").tag("|")
+                    Text("space").tag(" ")
+                }
+                .pickerStyle(.segmented)
+                .fixedSize()
+                .labelsHidden()
+            }
+
+            HStack {
+                Text("Font size")
+                Spacer()
+                Picker("Font size", selection: $settings.fontSize) {
+                    Text("S").tag(BubbleSettings.FontSize.small)
+                    Text("M").tag(BubbleSettings.FontSize.medium)
+                    Text("L").tag(BubbleSettings.FontSize.large)
+                }
+                .pickerStyle(.segmented)
+                .fixedSize()
+                .labelsHidden()
+            }
+
+            HStack {
+                Text("Opacity")
+                Slider(value: $settings.opacity, in: 0.6...1.0)
+                Text("\(Int(settings.opacity * 100))%")
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+                    .frame(width: 36)
+            }
+
+            HStack {
+                Text("Theme")
+                Spacer()
+                Picker("Theme", selection: $settings.theme) {
+                    ForEach(BubbleSettings.Theme.allCases, id: \.self) {
+                        Text($0.displayName).tag($0)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .fixedSize()
+                .labelsHidden()
+            }
+        }
+    }
+
+    // MARK: Filter & Sort
+
+    private var filterSection: some View {
+        Section("Filter & Sort") {
+            Stepper(
+                "Max sessions: \(settings.maxSessions)",
+                value: $settings.maxSessions,
+                in: 1...10
+            )
+
+            Picker("Show sessions", selection: $settings.minStateFilter) {
+                ForEach(MinStateFilter.allCases, id: \.self) {
+                    Text($0.displayName).tag($0)
+                }
+            }
+
+            Toggle("Use multi-agent bubble", isOn: $settings.multiAgentBubbleEnabled)
+            Toggle("Group by agent kind", isOn: $settings.groupByKind)
+            Toggle("Collapse same session id", isOn: $settings.collapseDuplicates)
+
+            Section("Hide agents") {
+                ForEach(AgentCatalog.all, id: \.kind) { agent in
+                    Toggle(agent.displayName, isOn: Binding(
+                        get: { !settings.hiddenKinds.contains(agent.kind) },
+                        set: { show in
+                            if show { settings.hiddenKinds.remove(agent.kind) }
+                            else    { settings.hiddenKinds.insert(agent.kind) }
+                        }
+                    ))
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Palette Chip
+
+private struct PaletteChip: View {
+    let token: BubbleToken
+    let onAdd: () -> Void
+
+    var body: some View {
+        Button(action: onAdd) {
+            HStack(spacing: 5) {
+                Image(systemName: token.chipSymbol)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(token.chipColor)
+                Text(token.shortName)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.primary.opacity(0.75))
+                Image(systemName: "plus")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(token.chipColor.opacity(0.7))
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(Capsule().fill(token.chipColor.opacity(0.10)))
+            .overlay(Capsule().strokeBorder(token.chipColor.opacity(0.30), lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Canvas Chip
+
+private struct CanvasChip: View {
+    let token: BubbleToken
+    let isDragging: Bool
+    let onRemove: () -> Void
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Image(systemName: token.chipSymbol)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(token.chipColor)
+            Text(token.shortName)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.primary.opacity(0.9))
+            Button { onRemove() } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(token.chipColor.opacity(0.6))
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(
+            Capsule().fill(
+                isDragging
+                    ? token.chipColor.opacity(0.25)
+                    : token.chipColor.opacity(0.13)
+            )
+        )
+        .overlay(
+            Capsule().strokeBorder(
+                isDragging ? token.chipColor : token.chipColor.opacity(0.45),
+                lineWidth: isDragging ? 1.5 : 1
+            )
+        )
+        .scaleEffect(isDragging ? 1.05 : 1.0)
+        .animation(.easeInOut(duration: 0.12), value: isDragging)
+    }
+}
+
+// MARK: - Drag & Drop Delegate
+
+private struct ChipDropDelegate: DropDelegate {
+    let target: BubbleToken
+    @Binding var tokens: [BubbleTokenItem]
+    @Binding var dragging: BubbleToken?
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        .init(operation: .move)
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        dragging = nil
+        return true
+    }
+
+    func dropEntered(info: DropInfo) {
+        guard let source = dragging, source != target else { return }
+        let visibleIndices = tokens.indices.filter { tokens[$0].isVisible }
+        guard let fromPos = visibleIndices.first(where: { tokens[$0].token == source }),
+              let toPos   = visibleIndices.first(where: { tokens[$0].token == target })
+        else { return }
+        withAnimation(.easeInOut(duration: 0.15)) {
+            tokens.move(
+                fromOffsets: IndexSet(integer: fromPos),
+                toOffset: toPos > fromPos ? toPos + 1 : toPos
+            )
+        }
+    }
+}
+
+// MARK: - Live Preview Row
+
+/// Renders a mock agent row using the current BubbleSettings, so the user
+/// can see exactly how the bubble will look as they edit the layout.
+private struct BubbleRowPreview: View {
+    @ObservedObject private var settings = BubbleSettings.shared
+
+    private let mockTitle    = "Fix login bug"
+    private let mockProject  = "agentpet"
+    private let mockMessage  = "Editing SettingsModel.swift"
+    private let mockElapsed  = "3m"
+
+    var body: some View {
+        let visible = settings.effectiveLayout.tokens.filter { $0.isVisible }
+
+        HStack(alignment: .center, spacing: 4) {
+            ForEach(visible) { item in
+                tokenView(for: item.token)
+            }
+            if visible.isEmpty {
+                Text("(empty)")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .frame(maxWidth: AgentBubble.contentMaxWidth, alignment: .leading)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color(nsColor: .textBackgroundColor).opacity(settings.opacity))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .strokeBorder(Color.primary.opacity(0.1), lineWidth: 1)
+        )
+    }
+
+    @ViewBuilder
+    private func tokenView(for token: BubbleToken) -> some View {
+        switch token {
+        case .dot:
+            Circle()
+                .fill(Color(red: 0.22, green: 0.53, blue: 1.0))
+                .frame(width: 6, height: 6)
+        case .icon:
+            ResolvedIconView(
+                choice: settings.iconChoice(for: .claude),
+                size: settings.fontSize.iconPt
+            )
+        case .title:
+            Text(mockTitle)
+                .font(.system(size: settings.fontSize.primaryPt, weight: .semibold))
+                .lineLimit(1)
+        case .project:
+            Text(mockProject)
+                .font(.system(size: settings.fontSize.primaryPt, weight: .medium))
+                .lineLimit(1)
+        case .separator:
+            Text(settings.separatorChar)
+                .font(.system(size: settings.fontSize.primaryPt))
+                .foregroundStyle(.secondary)
+        case .message:
+            Text(mockMessage)
+                .font(.system(size: settings.fontSize.primaryPt, weight: .medium))
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .layoutPriority(1)
+        case .stateLabel:
+            Text("Working")
+                .font(.system(size: settings.fontSize.secondaryPt))
+                .foregroundStyle(.secondary)
+        case .elapsed:
+            Text(mockElapsed)
+                .font(.system(size: settings.fontSize.secondaryPt))
+                .foregroundStyle(.tertiary)
+                .monospacedDigit()
+        }
+    }
+}
+
+// MARK: - Icon Picker Popover
+
+struct IconPickerPopover: View {
+    let kind: AgentKind
+    @ObservedObject private var settings = BubbleSettings.shared
+    @State private var search = ""
+
+    private var filteredSymbols: [String] {
+        search.isEmpty
+            ? AgentIcons.curatedSymbols
+            : AgentIcons.curatedSymbols.filter { $0.localizedCaseInsensitiveContains(search) }
+    }
+
+    private var kindName: String {
+        AgentCatalog.all.first { $0.kind == kind }?.displayName ?? kind.rawValue
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Icon for \(kindName)")
+                .font(.headline)
+                .padding([.horizontal, .top])
+                .padding(.bottom, 8)
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    brandSection
+                    symbolSection
+                }
+                .padding(.vertical, 12)
+            }
+
+            Divider()
+
+            HStack {
+                Button("Reset to default") {
+                    settings.resetIconChoice(for: kind)
+                }
+                .controlSize(.small)
+                Spacer()
+            }
+            .padding()
+        }
+        .frame(width: 320, height: 380)
+        .preferredColorScheme(.dark)
+    }
+
+    private var brandSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Brand logos")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal)
+
+            LazyVGrid(
+                columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 6),
+                spacing: 8
+            ) {
+                ForEach(AgentIcons.brandKinds, id: \.self) { logoKind in
+                    iconCell(choice: .brandLogo(logoKind)) {
+                        ResolvedIconView(choice: .brandLogo(logoKind), size: 22)
+                    }
+                }
+            }
+            .padding(.horizontal)
+        }
+    }
+
+    private var symbolSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("SF Symbols")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                TextField("Search", text: $search)
+                    .textFieldStyle(.roundedBorder)
+                    .controlSize(.small)
+                    .frame(width: 110)
+            }
+            .padding(.horizontal)
+
+            LazyVGrid(
+                columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 6),
+                spacing: 8
+            ) {
+                ForEach(filteredSymbols, id: \.self) { sym in
+                    iconCell(choice: .sfSymbol(sym)) {
+                        Image(systemName: sym)
+                            .font(.system(size: 18))
+                            .frame(width: 22, height: 22)
+                    }
+                }
+            }
+            .padding(.horizontal)
+        }
+    }
+
+    @ViewBuilder
+    private func iconCell<Content: View>(
+        choice: IconChoice,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        let selected = settings.iconChoice(for: kind) == choice
+        Button {
+            settings.setIconChoice(choice, for: kind)
+        } label: {
+            content()
+                .frame(width: 36, height: 36)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(selected ? Color.accentColor.opacity(0.25) : Color.white.opacity(0.06))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .strokeBorder(selected ? Color.accentColor : .clear, lineWidth: 1.5)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/Sources/App/BubbleSettingsView.swift
+++ b/Sources/App/BubbleSettingsView.swift
@@ -6,20 +6,94 @@ import UniformTypeIdentifiers
 
 struct BubbleSettingsView: View {
     @ObservedObject private var settings = BubbleSettings.shared
+    @ObservedObject private var pet = PetController.shared
+    @ObservedObject private var chat = ChatSettings.shared
     @State private var dragging: BubbleToken?
     @State private var iconPickerKind: AgentKind?
 
     var body: some View {
         Form {
-            paletteSection
-            canvasSection
-            agentIconsSection
-            appearanceSection
-            filterSection
+            modeSection
+            if settings.multiAgentBubbleEnabled {
+                paletteSection
+                canvasSection
+                agentIconsSection
+                appearanceSection
+                filterSection
+            } else {
+                defaultBubbleSection
+            }
         }
         .formStyle(.grouped)
         .popover(item: $iconPickerKind) { kind in
             IconPickerPopover(kind: kind)
+        }
+    }
+
+    // MARK: Mode toggle
+
+    private var modeSection: some View {
+        Section {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Multi-agent bubble")
+                    Text("Show all active agents with icons, state dots, and custom layout.")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+                Spacer()
+                ColorSwitch(isOn: $settings.multiAgentBubbleEnabled)
+            }
+        } header: {
+            Text("Bubble mode")
+        }
+    }
+
+    // MARK: Default mode config (shown when multi-agent is OFF)
+
+    private var defaultBubbleSection: some View {
+        Section("Default bubble") {
+            HStack {
+                Text("Show chat bubble")
+                Spacer()
+                ColorSwitch(isOn: $pet.showChat)
+            }
+            Picker("Messages", selection: $chat.source) {
+                Text("System").tag(ChatSettings.Source.system)
+                Text("Custom").tag(ChatSettings.Source.custom)
+            }
+            .pickerStyle(.segmented)
+            if chat.source == .custom {
+                ForEach(ChatSettings.editableMoods, id: \.self) { mood in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(moodLabel(mood)).font(.caption).foregroundStyle(.secondary)
+                        GrowingTextEditor(text: Binding(
+                            get: { chat.text(for: mood) },
+                            set: { chat.setText($0, for: mood) }
+                        ))
+                        .padding(4)
+                        .background(RoundedRectangle(cornerRadius: 6).fill(Color(white: 0.16)))
+                        .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(.white.opacity(0.12)))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+                HStack {
+                    Text("One message per line; a random one is shown.")
+                        .font(.caption).foregroundStyle(.secondary)
+                    Spacer()
+                    Button("Reset to defaults") { chat.resetToDefaults() }
+                        .controlSize(.small)
+                }
+            }
+        }
+    }
+
+    private func moodLabel(_ mood: PetMood) -> String {
+        switch mood {
+        case .working:   return "Working"
+        case .waiting:   return "Waiting"
+        case .done:      return "Done"
+        case .celebrate: return "Celebrate"
+        case .idle:      return "Idle"
         }
     }
 
@@ -243,7 +317,6 @@ struct BubbleSettingsView: View {
                 }
             }
 
-            Toggle("Use multi-agent bubble", isOn: $settings.multiAgentBubbleEnabled)
             Toggle("Group by agent kind", isOn: $settings.groupByKind)
             Toggle("Collapse same session id", isOn: $settings.collapseDuplicates)
 

--- a/Sources/App/BubbleSettingsView.swift
+++ b/Sources/App/BubbleSettingsView.swift
@@ -15,7 +15,6 @@ struct BubbleSettingsView: View {
         Form {
             modeSection
             if settings.multiAgentBubbleEnabled {
-                previewSection
                 agentsSection
                 rowLayoutSection
                 iconsSection
@@ -100,20 +99,7 @@ struct BubbleSettingsView: View {
         }
     }
 
-    // MARK: - 2. Preview
-
-    private var previewSection: some View {
-        Section {
-            BubbleRowPreview()
-                .frame(maxWidth: .infinity, alignment: .leading)
-        } header: {
-            Text("Preview")
-        } footer: {
-            Text("Sample row using your current layout and style settings.")
-        }
-    }
-
-    // MARK: - 3. Agents — what to show
+    // MARK: - 2. Agents — what to show
 
     private var agentsSection: some View {
         Group {
@@ -192,7 +178,7 @@ struct BubbleSettingsView: View {
         return "Max \(noun): \(settings.maxSessions)"
     }
 
-    // MARK: - 4. Row layout — tokens & order
+    // MARK: - 3. Row layout — preview + tokens
 
     private var inactiveTokens: [BubbleToken] {
         BubbleToken.allCases.filter { token in
@@ -206,6 +192,15 @@ struct BubbleSettingsView: View {
 
     private var rowLayoutSection: some View {
         Section {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Preview")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                BubbleRowPreview()
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.bottom, 4)
+
             if inactiveTokens.isEmpty {
                 Text("All tokens are in use")
                     .font(.caption)
@@ -269,7 +264,7 @@ struct BubbleSettingsView: View {
         } header: {
             Text("Row content")
         } footer: {
-            Text("Tap to add · drag to reorder · × to remove. Controls what each agent row shows.")
+            Text("Preview updates as you add, remove, or reorder tokens below.")
         }
     }
 
@@ -291,7 +286,7 @@ struct BubbleSettingsView: View {
         }
     }
 
-    // MARK: - 5. Icons
+    // MARK: - 4. Icons
 
     private var iconsSection: some View {
         Section {
@@ -309,7 +304,7 @@ struct BubbleSettingsView: View {
         }
     }
 
-    // MARK: - 6. Style
+    // MARK: - 5. Style
 
     private var styleSection: some View {
         Section {
@@ -366,7 +361,7 @@ struct BubbleSettingsView: View {
         }
     }
 
-    // MARK: - 7. Activity phrases
+    // MARK: - 6. Activity phrases
 
     private var activitySection: some View {
         Section {

--- a/Sources/App/BubbleSettingsView.swift
+++ b/Sources/App/BubbleSettingsView.swift
@@ -15,11 +15,12 @@ struct BubbleSettingsView: View {
         Form {
             modeSection
             if settings.multiAgentBubbleEnabled {
-                paletteSection
-                canvasSection
-                agentIconsSection
-                appearanceSection
-                filterSection
+                previewSection
+                agentsSection
+                rowLayoutSection
+                iconsSection
+                styleSection
+                activitySection
             } else {
                 defaultBubbleSection
             }
@@ -30,14 +31,14 @@ struct BubbleSettingsView: View {
         }
     }
 
-    // MARK: Mode toggle
+    // MARK: - 1. Mode
 
     private var modeSection: some View {
         Section {
             HStack {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Multi-agent bubble")
-                    Text("Show all active agents with icons, state dots, and custom layout.")
+                    Text("Structured rows with icons, state dots, and activity messages.")
                         .font(.caption).foregroundStyle(.secondary)
                 }
                 Spacer()
@@ -48,10 +49,8 @@ struct BubbleSettingsView: View {
         }
     }
 
-    // MARK: Default mode config (shown when multi-agent is OFF)
-
     private var defaultBubbleSection: some View {
-        Section("Default bubble") {
+        Section {
             HStack {
                 Text("Show chat bubble")
                 Spacer()
@@ -84,6 +83,10 @@ struct BubbleSettingsView: View {
                         .controlSize(.small)
                 }
             }
+        } header: {
+            Text("Simple bubble")
+        } footer: {
+            Text("Turn on multi-agent bubble above for per-agent rows with icons and activity.")
         }
     }
 
@@ -97,7 +100,99 @@ struct BubbleSettingsView: View {
         }
     }
 
-    // MARK: Available tokens (palette)
+    // MARK: - 2. Preview
+
+    private var previewSection: some View {
+        Section {
+            BubbleRowPreview()
+                .frame(maxWidth: .infinity, alignment: .leading)
+        } header: {
+            Text("Preview")
+        } footer: {
+            Text("Sample row using your current layout and style settings.")
+        }
+    }
+
+    // MARK: - 3. Agents — what to show
+
+    private var agentsSection: some View {
+        Group {
+            Section {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Sessions")
+                        .font(.subheadline)
+                    Picker("Sessions", selection: $settings.sessionGrouping) {
+                        ForEach(BubbleSessionGrouping.allCases, id: \.self) { mode in
+                            Text(mode.displayName).tag(mode)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                    Text(settings.sessionGrouping.detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Rows")
+                        .font(.subheadline)
+                    Picker("Rows", selection: $settings.displayMode) {
+                        ForEach(BubbleDisplayMode.allCases, id: \.self) { mode in
+                            Text(mode.displayName).tag(mode)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                    Text(settings.displayMode.detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                if settings.displayMode != .carousel {
+                    Stepper(maxRowsLabel, value: $settings.maxSessions, in: 1...10)
+                }
+
+                if settings.sessionGrouping == .allSessions {
+                    Toggle("Sort by agent kind", isOn: $settings.groupByKind)
+                }
+            } header: {
+                Text("Display")
+            }
+
+            Section {
+                Picker("Include states", selection: $settings.minStateFilter) {
+                    ForEach(MinStateFilter.allCases, id: \.self) {
+                        Text($0.displayName).tag($0)
+                    }
+                }
+            } header: {
+                Text("Filter")
+            } footer: {
+                Text("Which session states appear in the bubble.")
+            }
+
+            Section {
+                ForEach(AgentCatalog.all, id: \.kind) { agent in
+                    Toggle(agent.displayName, isOn: Binding(
+                        get: { !settings.hiddenKinds.contains(agent.kind) },
+                        set: { show in
+                            if show { settings.hiddenKinds.remove(agent.kind) }
+                            else    { settings.hiddenKinds.insert(agent.kind) }
+                        }
+                    ))
+                }
+            } header: {
+                Text("Visible agents")
+            }
+        }
+    }
+
+    private var maxRowsLabel: String {
+        let noun = settings.sessionGrouping == .byKind ? "agent kinds" : "sessions"
+        return "Max \(noun): \(settings.maxSessions)"
+    }
+
+    // MARK: - 4. Row layout — tokens & order
 
     private var inactiveTokens: [BubbleToken] {
         BubbleToken.allCases.filter { token in
@@ -109,14 +204,12 @@ struct BubbleSettingsView: View {
         settings.customLayout.tokens.filter { $0.isVisible }
     }
 
-    private var paletteSection: some View {
+    private var rowLayoutSection: some View {
         Section {
             if inactiveTokens.isEmpty {
-                Text("All tokens are active")
+                Text("All tokens are in use")
                     .font(.caption)
                     .foregroundStyle(.tertiary)
-                    .frame(maxWidth: .infinity, alignment: .center)
-                    .padding(.vertical, 4)
             } else {
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: 8) {
@@ -124,93 +217,61 @@ struct BubbleSettingsView: View {
                             PaletteChip(token: token) { addToken(token) }
                         }
                     }
-                    .padding(.horizontal, 2)
                     .padding(.vertical, 2)
                 }
             }
-        } header: {
-            Text("Available tokens")
-        } footer: {
-            Text("Tap a chip to add it to the bubble layout.")
-        }
-    }
 
-    // MARK: Active canvas + preview
-
-    private var canvasSection: some View {
-        Section {
-            VStack(alignment: .leading, spacing: 0) {
-                // Chip row
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 8) {
-                        if activeTokenItems.isEmpty {
-                            Text("Add tokens from above")
-                                .font(.caption)
-                                .foregroundStyle(.tertiary)
-                                .frame(height: 36)
-                        } else {
-                            ForEach(activeTokenItems) { item in
-                                CanvasChip(
-                                    token: item.token,
-                                    isDragging: dragging == item.token
-                                ) {
-                                    removeToken(item.token)
-                                }
-                                .onDrag {
-                                    dragging = item.token
-                                    return NSItemProvider(object: item.token.rawValue as NSString)
-                                }
-                                .onDrop(
-                                    of: [UTType.plainText],
-                                    delegate: ChipDropDelegate(
-                                        target: item.token,
-                                        tokens: $settings.customLayout.tokens,
-                                        dragging: $dragging
-                                    )
-                                )
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    if activeTokenItems.isEmpty {
+                        Text("Tap a chip above to add tokens")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                            .frame(height: 36)
+                    } else {
+                        ForEach(activeTokenItems) { item in
+                            CanvasChip(
+                                token: item.token,
+                                isDragging: dragging == item.token
+                            ) {
+                                removeToken(item.token)
                             }
+                            .onDrag {
+                                dragging = item.token
+                                return NSItemProvider(object: item.token.rawValue as NSString)
+                            }
+                            .onDrop(
+                                of: [UTType.plainText],
+                                delegate: ChipDropDelegate(
+                                    target: item.token,
+                                    tokens: $settings.customLayout.tokens,
+                                    dragging: $dragging
+                                )
+                            )
                         }
                     }
-                    .padding(.horizontal, 2)
-                    .padding(.vertical, 6)
                 }
+                .padding(.vertical, 4)
+            }
 
-                Divider()
-
-                // Live preview
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Preview")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    BubbleRowPreview()
-                }
-                .padding(.vertical, 10)
-
-                Divider()
-
-                // Reset shortcuts
-                HStack(spacing: 8) {
-                    Text("Reset:")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    Button("Original") { settings.customLayout = .original }
-                        .controlSize(.small)
-                    Button("Standard") { settings.customLayout = .standard }
-                        .controlSize(.small)
-                    Button("Detailed") { settings.customLayout = .detailed }
-                        .controlSize(.small)
-                    Spacer()
-                }
-                .padding(.vertical, 8)
+            HStack(spacing: 8) {
+                Text("Presets")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Button("Original") { settings.customLayout = .original }
+                    .controlSize(.small)
+                Button("Standard") { settings.customLayout = .standard }
+                    .controlSize(.small)
+                Button("Detailed") { settings.customLayout = .detailed }
+                    .controlSize(.small)
+                Spacer()
             }
         } header: {
-            Text("Bubble layout")
+            Text("Row content")
         } footer: {
-            Text("Drag chips to reorder · × to remove")
+            Text("Tap to add · drag to reorder · × to remove. Controls what each agent row shows.")
         }
     }
-
-    // MARK: Helpers
 
     private func addToken(_ token: BubbleToken) {
         withAnimation(.easeOut(duration: 0.18)) {
@@ -230,10 +291,10 @@ struct BubbleSettingsView: View {
         }
     }
 
-    // MARK: Agent Icons
+    // MARK: - 5. Icons
 
-    private var agentIconsSection: some View {
-        Section("Agent Icons") {
+    private var iconsSection: some View {
+        Section {
             ForEach(AgentCatalog.all, id: \.kind) { agent in
                 HStack(spacing: 10) {
                     ResolvedIconView(choice: settings.iconChoice(for: agent.kind), size: 20)
@@ -243,13 +304,15 @@ struct BubbleSettingsView: View {
                         .controlSize(.small)
                 }
             }
+        } header: {
+            Text("Agent icons")
         }
     }
 
-    // MARK: Appearance
+    // MARK: - 6. Style
 
-    private var appearanceSection: some View {
-        Section("Appearance") {
+    private var styleSection: some View {
+        Section {
             HStack {
                 Text("Separator")
                 Spacer()
@@ -298,45 +361,24 @@ struct BubbleSettingsView: View {
                 .fixedSize()
                 .labelsHidden()
             }
+        } header: {
+            Text("Style")
+        }
+    }
 
-            Picker("Activity style", selection: $settings.activityTheme) {
+    // MARK: - 7. Activity phrases
+
+    private var activitySection: some View {
+        Section {
+            Picker("Vocabulary", selection: $settings.activityTheme) {
                 ForEach(ActivityTheme.allCases, id: \.self) { theme in
                     Text("\(theme.emoji) \(theme.displayName)").tag(theme)
                 }
             }
-        }
-    }
-
-    // MARK: Filter & Sort
-
-    private var filterSection: some View {
-        Section("Filter & Sort") {
-            Stepper(
-                "Max sessions: \(settings.maxSessions)",
-                value: $settings.maxSessions,
-                in: 1...10
-            )
-
-            Picker("Show sessions", selection: $settings.minStateFilter) {
-                ForEach(MinStateFilter.allCases, id: \.self) {
-                    Text($0.displayName).tag($0)
-                }
-            }
-
-            Toggle("Group by agent kind", isOn: $settings.groupByKind)
-            Toggle("Collapse same session id", isOn: $settings.collapseDuplicates)
-
-            Section("Hide agents") {
-                ForEach(AgentCatalog.all, id: \.kind) { agent in
-                    Toggle(agent.displayName, isOn: Binding(
-                        get: { !settings.hiddenKinds.contains(agent.kind) },
-                        set: { show in
-                            if show { settings.hiddenKinds.remove(agent.kind) }
-                            else    { settings.hiddenKinds.insert(agent.kind) }
-                        }
-                    ))
-                }
-            }
+        } header: {
+            Text("Activity messages")
+        } footer: {
+            Text("Whimsical phrases shown while agents work, e.g. \"Brewing…\" or \"Compiling…\".")
         }
     }
 }

--- a/Sources/App/BubbleSettingsView.swift
+++ b/Sources/App/BubbleSettingsView.swift
@@ -298,6 +298,12 @@ struct BubbleSettingsView: View {
                 .fixedSize()
                 .labelsHidden()
             }
+
+            Picker("Activity style", selection: $settings.activityTheme) {
+                ForEach(ActivityTheme.allCases, id: \.self) { theme in
+                    Text("\(theme.emoji) \(theme.displayName)").tag(theme)
+                }
+            }
         }
     }
 

--- a/Sources/App/IdleBoost.swift
+++ b/Sources/App/IdleBoost.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+enum IdleBoost {
+    static let lines = [
+        "Let's grill some bugs.",
+        "I miss you. Open a branch for me.",
+        "Tiny commit, tiny dopamine.",
+        "The build is quiet. Too quiet.",
+        "Ship something small. Future you is watching.",
+        "Your TODOs are pretending not to see us.",
+        "No agents running. The keyboard has entered standby drama.",
+        "Turn coffee into code. Carefully.",
+        "Open one file. Intimidate it professionally.",
+        "The repo is calm. Suspicious, but calm.",
+        "Refactor lightly. Leave with dignity.",
+        "One clean diff can fix the whole afternoon.",
+    ]
+
+    static func line(at date: Date = Date()) -> String {
+        let minute = max(0, Int(date.timeIntervalSince1970 / 60))
+        return lines[minute % lines.count]
+    }
+}

--- a/Sources/App/MenuBarContentView.swift
+++ b/Sources/App/MenuBarContentView.swift
@@ -103,6 +103,7 @@ struct MenuContentView: View {
             controlRow(icon: "pawprint", label: "Show pet", isOn: $petWindow.isVisible)
             controlRow(icon: "number", label: "Show count on menu bar", isOn: $statusBar.showCount)
             controlRow(icon: "bubble.left", label: "Show chat on menu bar", isOn: $statusBar.showChatOnMenuBar)
+            controlRow(icon: "list.bullet.rectangle", label: "Show bubble on menu bar", isOn: $statusBar.showBubbleOnMenuBar)
             sizeRow
         }
     }
@@ -131,19 +132,23 @@ struct MenuContentView: View {
 
     // MARK: Footer
 
+    @ObservedObject private var updater = UpdaterController.shared
+
     private var footer: some View {
         HStack {
             FooterButton(icon: "gearshape", label: "Settings") {
-                dismiss()
-                // Open after the popover finishes closing so the window
-                // reliably comes to the front.
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                // Use closeAndThen so the window appears only after the popover
+                // animation fully completes — no race, no overlap.
+                StatusBarController.shared.closeAndThen {
                     SettingsWindowController.shared.show()
                 }
             }
-            FooterButton(icon: "arrow.triangle.2.circlepath", label: "Updates") {
-                dismiss()
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            FooterButton(
+                icon: "arrow.triangle.2.circlepath",
+                label: "Updates",
+                badge: updater.updatePending
+            ) {
+                StatusBarController.shared.closeAndThen {
                     UpdaterController.shared.checkForUpdates()
                 }
             }
@@ -156,15 +161,37 @@ struct MenuContentView: View {
     }
 }
 
+// MARK: - Menu bar hanging bubble
+
+/// Thin wrapper so the agent bubble shown below the menu bar icon
+/// auto-refreshes via @ObservedObject without re-creating the NSPanel.
+struct MenuBarBubbleView: View {
+    @ObservedObject private var pet = PetController.shared
+
+    var body: some View {
+        AgentBubble(sessions: pet.activeAgentSessions, tailEdge: .top)
+            .environment(\.colorScheme, .dark)
+    }
+}
+
 private struct FooterButton: View {
     let icon: String
     let label: String
+    var badge: Bool = false
     let action: () -> Void
 
     var body: some View {
         Button(action: action) {
             HStack(spacing: 5) {
-                Image(systemName: icon)
+                ZStack(alignment: .topTrailing) {
+                    Image(systemName: icon)
+                    if badge {
+                        Circle()
+                            .fill(Color.orange)
+                            .frame(width: 6, height: 6)
+                            .offset(x: 4, y: -4)
+                    }
+                }
                 Text(label)
             }
             .font(.system(size: 12, weight: .medium))

--- a/Sources/App/MenuBarContentView.swift
+++ b/Sources/App/MenuBarContentView.swift
@@ -77,9 +77,18 @@ struct MenuContentView: View {
                 }
             }
             if agents.isEmpty {
-                Text("Nothing running right now.")
-                    .font(.system(size: 12)).foregroundStyle(.white.opacity(0.4))
+                TimelineView(.periodic(from: .now, by: 60)) { context in
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text("Nothing running right now.")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(.white.opacity(0.55))
+                        Text(IdleBoost.line(at: context.date))
+                            .font(.system(size: 12))
+                            .foregroundStyle(.white.opacity(0.4))
+                            .lineLimit(2)
+                    }
                     .padding(.horizontal, 14).padding(.bottom, 12)
+                }
             } else {
                 ForEach(agents) { session in
                     AgentRow(session: session, onClear: { daemon.removeSession(session.id) })

--- a/Sources/App/PetController.swift
+++ b/Sources/App/PetController.swift
@@ -134,8 +134,13 @@ final class PetController: ObservableObject {
     }
 
     private func refreshChat() {
-        guard showChat, mood != .idle else {
+        guard showChat else {
             chatLine = ""
+            StatusBarController.shared.refreshTitle()
+            return
+        }
+        if mood == .idle {
+            chatLine = IdleBoost.line()
             StatusBarController.shared.refreshTitle()
             return
         }

--- a/Sources/App/PetController.swift
+++ b/Sources/App/PetController.swift
@@ -117,10 +117,28 @@ final class PetController: ObservableObject {
         setMood(resolved)
 
         if resolved == .working || resolved == .waiting {
-            buildAgentChatLine(sessions: sessions)
+            if BubbleSettings.shared.multiAgentBubbleEnabled {
+                buildAgentChatLine(sessions: sessions)
+            } else {
+                chatLineCount = 0
+                activeAgentSessions = []
+                refreshChat()
+            }
         } else {
             chatLineCount = 0
             activeAgentSessions = []
+        }
+    }
+
+    /// Rebuilds chat state when the user toggles multi-agent bubble mode.
+    func applyBubbleModeChange() {
+        guard mood == .working || mood == .waiting else { return }
+        if BubbleSettings.shared.multiAgentBubbleEnabled {
+            buildAgentChatLine(sessions: latestSessions)
+        } else {
+            chatLineCount = 0
+            activeAgentSessions = []
+            refreshChat()
         }
     }
 
@@ -144,10 +162,10 @@ final class PetController: ObservableObject {
             StatusBarController.shared.refreshTitle()
             return
         }
-        // During working/waiting the agent list owns chatLine; fall back to
-        // PetChat for celebrate/done.
-        if (mood == .working || mood == .waiting) && chatLineCount > 0 {
-            // chatLine already set by buildAgentChatLine — just refresh status bar
+        // Multi-agent mode owns chatLine during working/waiting; otherwise use PetChat.
+        if (mood == .working || mood == .waiting)
+            && BubbleSettings.shared.multiAgentBubbleEnabled
+            && chatLineCount > 0 {
             StatusBarController.shared.refreshTitle()
             return
         }

--- a/Sources/App/PetController.swift
+++ b/Sources/App/PetController.swift
@@ -28,16 +28,26 @@ final class PetController: ObservableObject {
     static let maxPoint: Double = 240
     static let presets: [(String, Double)] = [("S", 84), ("M", 120), ("L", 168)]
 
-    /// Floating window size for a sprite point size (room for the bubble above).
-    static func windowSize(forPoint point: Double) -> CGSize {
-        CGSize(width: point + 110, height: point + 64)
+    /// Floating window size. Width is wide enough for agent-ticker lines;
+    /// height grows with the number of lines in the bubble.
+    static func windowSize(forPoint point: Double, lineCount: Int = 1) -> CGSize {
+        let count = max(lineCount, 1)
+        let bubbleH = CGFloat(count) * 22 + 16   // 22pt per line + top/bottom padding
+        return CGSize(
+            width: max(point + 110, 320),         // 320pt fits typical agent lines
+            height: point + bubbleH + 28          // 28pt for triangle + spacing + margin
+        )
     }
-    var windowSize: CGSize { Self.windowSize(forPoint: petPoint) }
+    var windowSize: CGSize { Self.windowSize(forPoint: petPoint, lineCount: max(chatLineCount, 1)) }
 
     private var lastResolved: PetMood = .idle
     private var latestSessions: [AgentSession] = []
     private var celebrateTimer: Timer?
-    private var chatTimer: Timer?
+
+    /// Number of active agent lines currently shown; drives window height.
+    @Published private(set) var chatLineCount: Int = 0
+    /// Sorted active sessions for the structured desktop bubble. Empty when idle/done/celebrate.
+    @Published private(set) var activeAgentSessions: [AgentSession] = []
 
     private static let petKey = "agentpet.selectedPetID"
     private static let chatKey = "agentpet.showChat"
@@ -52,10 +62,7 @@ final class PetController: ObservableObject {
     }
 
     func start() {
-        // Vary the chat line periodically while the pet is active.
-        chatTimer = Timer.scheduledTimer(withTimeInterval: 5, repeats: true) { _ in
-            Task { @MainActor [weak self] in self?.refreshChat() }
-        }
+        // Ticker drives chatLine updates; no separate chat timer needed.
     }
 
     private var sizeAnimTimer: Timer?
@@ -94,6 +101,8 @@ final class PetController: ObservableObject {
         defer { lastResolved = resolved }
 
         if resolved == .done && lastResolved != .done {
+            chatLineCount = 0
+            activeAgentSessions = []
             setMood(.celebrate)
             celebrateTimer?.invalidate()
             celebrateTimer = Timer.scheduledTimer(withTimeInterval: Self.celebrateDuration, repeats: false) { _ in
@@ -101,11 +110,18 @@ final class PetController: ObservableObject {
             }
             return
         }
-        if mood == .celebrate && resolved == .done {
-            return  // let the celebration finish
+        if mood == .celebrate {
+            return  // let the 3-second celebration finish regardless of new state
         }
         celebrateTimer?.invalidate()
         setMood(resolved)
+
+        if resolved == .working || resolved == .waiting {
+            buildAgentChatLine(sessions: sessions)
+        } else {
+            chatLineCount = 0
+            activeAgentSessions = []
+        }
     }
 
     private func settleAfterCelebrate() {
@@ -118,13 +134,43 @@ final class PetController: ObservableObject {
     }
 
     private func refreshChat() {
+        guard showChat, mood != .idle else {
+            chatLine = ""
+            StatusBarController.shared.refreshTitle()
+            return
+        }
+        // During working/waiting the agent list owns chatLine; fall back to
+        // PetChat for celebrate/done.
+        if (mood == .working || mood == .waiting) && chatLineCount > 0 {
+            // chatLine already set by buildAgentChatLine — just refresh status bar
+            StatusBarController.shared.refreshTitle()
+            return
+        }
         let pool = ChatSettings.shared.lines(for: mood)
-        guard showChat, mood != .idle, !pool.isEmpty else {
+        guard !pool.isEmpty else {
             chatLine = ""
             StatusBarController.shared.refreshTitle()
             return
         }
         chatLine = pool.randomElement() ?? ""
+        StatusBarController.shared.refreshTitle()
+    }
+
+    // MARK: - Agent list
+
+    /// Builds the structured session list and a plain-text fallback chatLine.
+    private func buildAgentChatLine(sessions: [AgentSession]) {
+        let active = TickerFormatter.sorted(
+            sessions.filter { $0.state != .idle && $0.state != .registered }
+        )
+        activeAgentSessions = active
+        chatLineCount = active.count
+        if active.isEmpty {
+            chatLine = ""
+        } else {
+            // Plain-text fallback used by the menu bar chat pill (lineLimit(1) shows first line).
+            chatLine = active.map { "• \(TickerFormatter.line(for: $0))" }.joined(separator: "\n")
+        }
         StatusBarController.shared.refreshTitle()
     }
 }

--- a/Sources/App/PetView.swift
+++ b/Sources/App/PetView.swift
@@ -136,6 +136,8 @@ struct AgentBubble: View {
     }
 
     private var isPetChat: Bool { tailEdge == .bottom }
+    // Use capsule only for a single-agent pet-chat bubble; switch to rounded rect for 2+ agents.
+    private var useCapsule: Bool { isPetChat && groupedSessions.count <= 1 }
 
     var body: some View {
         let fill = isPetChat ? Color.white : bubbleFill
@@ -156,14 +158,14 @@ struct AgentBubble: View {
             .padding(.horizontal, 12)
             .padding(.vertical, isPetChat ? 7 : 9)
             .background {
-                if isPetChat {
+                if useCapsule {
                     Capsule().fill(fill)
                 } else {
                     RoundedRectangle(cornerRadius: 14, style: .continuous).fill(fill)
                 }
             }
             .overlay {
-                if isPetChat {
+                if useCapsule {
                     Capsule().strokeBorder(stroke, lineWidth: 1)
                 } else {
                     RoundedRectangle(cornerRadius: 14, style: .continuous).strokeBorder(stroke, lineWidth: 1)
@@ -245,6 +247,7 @@ private struct AgentRow: View {
             .modifier(WaitingTextFlash(active: isWaiting))
         }
         .frame(maxWidth: rowMaxWidth, alignment: .leading)
+        .animation(.spring(response: 0.3, dampingFraction: 0.75), value: session.message)
     }
 
     @ViewBuilder
@@ -285,6 +288,8 @@ private struct AgentRow: View {
                 .truncationMode(.tail)
                 .layoutPriority(1)
                 .fixedSize(horizontal: false, vertical: true)
+                .contentTransition(.opacity)
+                .id(messageText)
         case .stateLabel:
             Text(session.state.rawValue.capitalized)
                 .font(.system(size: secondaryPt, weight: .regular))
@@ -317,7 +322,9 @@ private struct AgentRow: View {
 
     private var messageText: String {
         let m = session.message?.trimmingCharacters(in: .whitespaces) ?? ""
-        return m.isEmpty ? session.state.rawValue.capitalized : m
+        if !m.isEmpty { return m }
+        return ClaudeActivityFormatter.stateMessage(for: session.state)
+            ?? session.state.rawValue.capitalized
     }
 
     private var stateDotColor: Color {

--- a/Sources/App/PetView.swift
+++ b/Sources/App/PetView.swift
@@ -151,8 +151,8 @@ struct AgentBubble: View {
     }
 
     var body: some View {
-        let fill = isPetChat ? Color.white : bubbleFill
-        let stroke = isPetChat ? Color.black.opacity(0.06) : borderColor
+        let fill = bubbleFill
+        let stroke = borderColor
 
         VStack(spacing: 0) {
             if tailEdge == .top {
@@ -232,7 +232,6 @@ struct AgentBubble: View {
     }
 
     private func textColor(_ opacity: Double) -> Color {
-        if isPetChat { return .black.opacity(opacity) }
         switch settings.theme {
         case .light:  return .black.opacity(opacity)
         case .dark:   return .white.opacity(opacity)
@@ -246,6 +245,7 @@ struct AgentBubble: View {
 private struct BubbleCarousel: View {
     let groups: [GroupedSession]
     var chatStyle: Bool = false
+    @ObservedObject private var settings = BubbleSettings.shared
     @State private var index = 0
     @State private var timer: Timer?
     @State private var dragOffset: CGFloat = 0
@@ -318,13 +318,16 @@ private struct BubbleCarousel: View {
             }
     }
 
-    private var dotActive: Color {
-        chatStyle ? .black.opacity(0.55) : Color.primary.opacity(0.7)
+    private func dotColor(_ opacity: Double) -> Color {
+        switch settings.theme {
+        case .light:  return .black.opacity(opacity)
+        case .dark:   return .white.opacity(opacity)
+        case .system: return Color.primary.opacity(opacity)
+        }
     }
 
-    private var dotInactive: Color {
-        chatStyle ? .black.opacity(0.2) : Color.primary.opacity(0.25)
-    }
+    private var dotActive: Color { dotColor(0.7) }
+    private var dotInactive: Color { dotColor(0.25) }
 
     private func step(by delta: Int) {
         guard groups.count > 1 else { return }
@@ -410,6 +413,7 @@ private struct BubbleCompactLayout: View {
     let totalCount: Int
     var chatStyle: Bool = false
     let textColor: (Double) -> Color
+    @ObservedObject private var settings = BubbleSettings.shared
     @State private var expanded = false
 
     private let visibleRows = 2
@@ -417,7 +421,7 @@ private struct BubbleCompactLayout: View {
     var body: some View {
         VStack(alignment: .leading, spacing: chatStyle ? 4 : 5) {
             Text(summaryLabel)
-                .font(.system(size: chatStyle ? 10 : 10.5, weight: .semibold))
+                .font(.system(size: settings.fontSize.secondaryPt, weight: .semibold))
                 .foregroundStyle(textColor(0.45))
 
             ForEach(visibleGroups) { group in
@@ -427,7 +431,7 @@ private struct BubbleCompactLayout: View {
             if hiddenCount > 0 {
                 Button(action: { withAnimation(.easeInOut(duration: 0.2)) { expanded.toggle() } }) {
                     Text(expanded ? "Show less" : "+\(hiddenCount) more")
-                        .font(.system(size: chatStyle ? 10 : 10.5, weight: .medium))
+                        .font(.system(size: settings.fontSize.secondaryPt, weight: .medium))
                         .foregroundStyle(textColor(0.5))
                 }
                 .buttonStyle(.plain)
@@ -468,9 +472,9 @@ private struct AgentRow: View {
     var chatStyle: Bool = false
     @ObservedObject private var settings = BubbleSettings.shared
 
-    private var primaryPt: CGFloat { chatStyle ? 12 : settings.fontSize.primaryPt }
-    private var secondaryPt: CGFloat { chatStyle ? 10.5 : settings.fontSize.secondaryPt }
-    private var iconPt: CGFloat { chatStyle ? 14 : settings.fontSize.iconPt }
+    private var primaryPt: CGFloat { settings.fontSize.primaryPt }
+    private var secondaryPt: CGFloat { settings.fontSize.secondaryPt }
+    private var iconPt: CGFloat { settings.fontSize.iconPt }
     private var rowMaxWidth: CGFloat {
         chatStyle ? AgentBubble.petContentMaxWidth : AgentBubble.contentMaxWidth
     }
@@ -564,7 +568,6 @@ private struct AgentRow: View {
     }
 
     private func textColor(_ opacity: Double) -> Color {
-        if chatStyle { return .black.opacity(opacity) }
         switch settings.theme {
         case .light:  return .black.opacity(opacity)
         case .dark:   return .white.opacity(opacity)
@@ -619,7 +622,7 @@ private struct ChatBubble: View {
             Text(text)
                 .font(.system(size: 12, weight: .medium))
                 .foregroundStyle(.black.opacity(0.85))
-                .lineLimit(2)
+                .lineLimit(1)
                 .truncationMode(.tail)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 7)

--- a/Sources/App/PetView.swift
+++ b/Sources/App/PetView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AgentPetCore
 
 /// The pet sprite alone (imported pack, reacting to mood). Shows a paw
 /// placeholder if no pet is selected yet.
@@ -26,25 +27,327 @@ struct PetView: View {
     }
 }
 
+/// Reports the natural size of the pet + bubble so the window can hug its content.
+private struct PetContentSizeKey: PreferenceKey {
+    static var defaultValue: CGSize { .zero }
+    static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
+        let next = nextValue()
+        if next.width > 0, next.height > 0 { value = next }
+    }
+}
+
 /// The full floating window content: a chat bubble above the pet.
 struct FloatingPetView: View {
     @ObservedObject private var pet = PetController.shared
+    @ObservedObject private var bubbleSettings = BubbleSettings.shared
 
     var body: some View {
         VStack(spacing: 2) {
-            if pet.showChat && !pet.chatLine.isEmpty && pet.selectedPetID != nil {
-                ChatBubble(text: pet.chatLine)
-                    .transition(.scale(scale: 0.6).combined(with: .opacity))
+            if pet.showChat && pet.selectedPetID != nil {
+                if bubbleSettings.multiAgentBubbleEnabled && !pet.activeAgentSessions.isEmpty {
+                    AgentBubble(sessions: pet.activeAgentSessions)
+                        .transition(AnyTransition.scale(scale: 0.6).combined(with: .opacity))
+                } else if !pet.chatLine.isEmpty {
+                    ChatBubble(text: pet.chatLine)
+                        .transition(AnyTransition.scale(scale: 0.6).combined(with: .opacity))
+                }
             }
             PetView(size: pet.petPoint)
         }
-        .frame(width: pet.windowSize.width, height: pet.windowSize.height, alignment: .bottom)
+        .fixedSize(horizontal: true, vertical: true)
+        .background(
+            GeometryReader { proxy in
+                Color.clear.preference(key: PetContentSizeKey.self, value: proxy.size)
+            }
+        )
+        .onPreferenceChange(PetContentSizeKey.self) { size in
+            PetWindowController.shared.resizeToContent(size)
+        }
         .animation(.spring(response: 0.35, dampingFraction: 0.7), value: pet.chatLine)
+        .animation(.spring(response: 0.35, dampingFraction: 0.7), value: pet.activeAgentSessions.count)
         .animation(.easeInOut, value: pet.showChat)
     }
 }
 
-/// A speech bubble with a little downward tail.
+// MARK: - Agent Bubble (structured rows for working/waiting)
+
+/// Sessions with the same agent kind + project are collapsed into one row.
+private struct GroupedSession: Identifiable {
+    let session: AgentSession   // highest-priority session in the group
+    let count: Int              // total sessions sharing this kind+project
+    var id: String { session.id }
+}
+
+/// Speech bubble listing one row per (agentKind, project) group.
+/// Applies filter/sort/cap from `BubbleSettings` before rendering.
+/// `tailEdge` controls whether the pointer arrow points down (pet) or up (menu bar).
+struct AgentBubble: View {
+    let sessions: [AgentSession]
+    var tailEdge: Edge = .bottom
+    @ObservedObject private var settings = BubbleSettings.shared
+
+    // attentionPriority is internal to AgentPetCore — use local rank
+    private func rank(_ s: AgentState) -> Int {
+        switch s { case .working: 4; case .waiting: 3; case .done: 2; case .registered: 1; case .idle: 0 }
+    }
+
+    private var groupedSessions: [GroupedSession] {
+        // 1. Filter
+        let filtered = sessions
+            .filter { !settings.hiddenKinds.contains($0.agentKind) }
+            .filter { settings.minStateFilter.includes($0.state) }
+
+        // 2. Sort
+        var sorted = filtered
+        if settings.groupByKind {
+            sorted.sort {
+                if $0.agentKind.rawValue != $1.agentKind.rawValue {
+                    return $0.agentKind.rawValue < $1.agentKind.rawValue
+                }
+                if rank($0.state) != rank($1.state) { return rank($0.state) > rank($1.state) }
+                return $0.updatedAt > $1.updatedAt
+            }
+        } else {
+            sorted.sort {
+                if rank($0.state) != rank($1.state) { return rank($0.state) > rank($1.state) }
+                return $0.updatedAt > $1.updatedAt
+            }
+        }
+
+        // 3. One row per session id. Collapse only exact duplicate ids (defensive).
+        var result: [GroupedSession]
+        if settings.collapseDuplicates {
+            var seen: [String: Int] = [:]
+            result = []
+            for s in sorted {
+                if let idx = seen[s.id] {
+                    result[idx] = GroupedSession(session: result[idx].session, count: result[idx].count + 1)
+                } else {
+                    seen[s.id] = result.count
+                    result.append(GroupedSession(session: s, count: 1))
+                }
+            }
+        } else {
+            result = sorted.map { GroupedSession(session: $0, count: 1) }
+        }
+
+        // 4. Cap to maxSessions
+        return Array(result.prefix(settings.maxSessions))
+    }
+
+    private var isPetChat: Bool { tailEdge == .bottom }
+
+    var body: some View {
+        let fill = isPetChat ? Color.white : bubbleFill
+        let stroke = isPetChat ? Color.black.opacity(0.06) : borderColor
+
+        VStack(spacing: 0) {
+            if tailEdge == .top {
+                Triangle()
+                    .fill(fill)
+                    .frame(width: 12, height: 7)
+                    .scaleEffect(x: 1, y: -1)
+            }
+            VStack(alignment: .leading, spacing: isPetChat ? 4 : 5) {
+                ForEach(groupedSessions) { group in
+                    AgentRow(session: group.session, count: group.count, chatStyle: isPetChat)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, isPetChat ? 7 : 9)
+            .background {
+                if isPetChat {
+                    Capsule().fill(fill)
+                } else {
+                    RoundedRectangle(cornerRadius: 14, style: .continuous).fill(fill)
+                }
+            }
+            .overlay {
+                if isPetChat {
+                    Capsule().strokeBorder(stroke, lineWidth: 1)
+                } else {
+                    RoundedRectangle(cornerRadius: 14, style: .continuous).strokeBorder(stroke, lineWidth: 1)
+                }
+            }
+            .shadow(color: .black.opacity(0.18), radius: 5, y: 2)
+            if tailEdge == .bottom {
+                Triangle()
+                    .fill(fill)
+                    .frame(width: 12, height: 7)
+            }
+        }
+        .fixedSize(horizontal: isPetChat, vertical: true)
+        .frame(maxWidth: 420, alignment: .leading)
+    }
+
+    /// Inner content width cap (bubble max minus horizontal padding).
+    static let contentMaxWidth: CGFloat = 396
+    /// Pet chat bubble hugs content; still capped for very long lines.
+    static let petContentMaxWidth: CGFloat = 320
+
+    private var bubbleFill: Color {
+        switch settings.theme {
+        case .light:  return Color.white.opacity(settings.opacity)
+        case .dark:   return Color(nsColor: .windowBackgroundColor).opacity(settings.opacity)
+        case .system: return Color(nsColor: .textBackgroundColor).opacity(settings.opacity)
+        }
+    }
+
+    private var borderColor: Color {
+        switch settings.theme {
+        case .light:  return .black.opacity(0.06)
+        case .dark:   return .white.opacity(0.12)
+        case .system: return Color.primary.opacity(0.08)
+        }
+    }
+}
+
+/// One row per agent session. Iterates `BubbleSettings.effectiveLayout` tokens
+/// in order on a single line; project/title shrink before the message does.
+private struct AgentRow: View {
+    let session: AgentSession
+    var count: Int = 1
+    var chatStyle: Bool = false
+    @ObservedObject private var settings = BubbleSettings.shared
+
+    private var primaryPt: CGFloat { chatStyle ? 12 : settings.fontSize.primaryPt }
+    private var secondaryPt: CGFloat { chatStyle ? 10.5 : settings.fontSize.secondaryPt }
+    private var iconPt: CGFloat { chatStyle ? 14 : settings.fontSize.iconPt }
+    private var rowMaxWidth: CGFloat {
+        chatStyle ? AgentBubble.petContentMaxWidth : AgentBubble.contentMaxWidth
+    }
+
+    private var isWaiting: Bool { session.state == .waiting }
+
+    var body: some View {
+        let visible = settings.effectiveLayout.tokens.filter { $0.isVisible && tokenHasValue($0.token) }
+
+        HStack(alignment: .center, spacing: 4) {
+            if visible.contains(where: { $0.token == .dot }) {
+                tokenView(for: .dot)
+            }
+            HStack(alignment: .center, spacing: 4) {
+                ForEach(visible.filter { $0.token != .dot }) { item in
+                    tokenView(for: item.token)
+                }
+                if count > 1 {
+                    Text("×\(count)")
+                        .font(.system(size: settings.fontSize.secondaryPt, weight: .semibold))
+                        .foregroundStyle(textColor(0.5))
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 1)
+                        .background(
+                            Capsule()
+                                .fill(textColor(0.08))
+                        )
+                }
+            }
+            .modifier(WaitingTextFlash(active: isWaiting))
+        }
+        .frame(maxWidth: rowMaxWidth, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private func tokenView(for token: BubbleToken) -> some View {
+        switch token {
+        case .dot:
+            StateDot(color: stateDotColor, style: dotStyle)
+        case .icon:
+            ResolvedIconView(
+                choice: settings.iconChoice(for: session.agentKind),
+                size: iconPt
+            )
+        case .title:
+            if let title = session.title {
+                Text(title)
+                    .font(.system(size: primaryPt, weight: .semibold))
+                    .foregroundStyle(textColor(0.85))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .layoutPriority(-1)
+            }
+        case .project:
+            Text(projectName)
+                .font(.system(size: primaryPt, weight: .medium))
+                .foregroundStyle(textColor(0.82))
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .layoutPriority(-1)
+        case .separator:
+            Text(settings.separatorChar)
+                .font(.system(size: primaryPt, weight: .regular))
+                .foregroundStyle(textColor(0.35))
+        case .message:
+            Text(messageText)
+                .font(.system(size: primaryPt, weight: .medium))
+                .foregroundStyle(textColor(0.82))
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .layoutPriority(1)
+                .fixedSize(horizontal: false, vertical: true)
+        case .stateLabel:
+            Text(session.state.rawValue.capitalized)
+                .font(.system(size: secondaryPt, weight: .regular))
+                .foregroundStyle(textColor(0.55))
+        case .elapsed:
+            Text(elapsedString(since: session.stateSince))
+                .font(.system(size: secondaryPt, weight: .regular))
+                .foregroundStyle(textColor(0.45))
+                .monospacedDigit()
+        }
+    }
+
+    private func tokenHasValue(_ token: BubbleToken) -> Bool {
+        if token == .title { return session.title != nil }
+        return true
+    }
+
+    private func textColor(_ opacity: Double) -> Color {
+        if chatStyle { return .black.opacity(opacity) }
+        switch settings.theme {
+        case .light:  return .black.opacity(opacity)
+        case .dark:   return .white.opacity(opacity)
+        case .system: return Color.primary.opacity(opacity)
+        }
+    }
+
+    private var projectName: String {
+        session.project.map { ($0 as NSString).lastPathComponent } ?? session.id
+    }
+
+    private var messageText: String {
+        let m = session.message?.trimmingCharacters(in: .whitespaces) ?? ""
+        return m.isEmpty ? session.state.rawValue.capitalized : m
+    }
+
+    private var stateDotColor: Color {
+        switch session.state {
+        case .waiting:           return .orange
+        case .working:           return Color(red: 0.22, green: 0.53, blue: 1.0)
+        case .done:              return Color(red: 0.13, green: 0.77, blue: 0.37)
+        case .idle, .registered: return .gray
+        }
+    }
+
+    private var dotStyle: StateDot.Style {
+        switch session.state {
+        case .working, .waiting, .done: return .pulse
+        default:                        return .plain
+        }
+    }
+
+    private func elapsedString(since date: Date) -> String {
+        let s = Int(Date().timeIntervalSince(date))
+        if s < 60  { return "\(s)s" }
+        let m = s / 60
+        if m < 60  { return "\(m)m" }
+        return "\(m / 60)h \(m % 60)m"
+    }
+}
+
+// MARK: - Simple Chat Bubble (celebrate / done / waiting fallback)
+
+/// A plain speech bubble with a downward tail, used for celebrate/done lines.
 private struct ChatBubble: View {
     let text: String
 
@@ -53,6 +356,8 @@ private struct ChatBubble: View {
             Text(text)
                 .font(.system(size: 12, weight: .medium))
                 .foregroundStyle(.black.opacity(0.85))
+                .lineLimit(2)
+                .truncationMode(.tail)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 7)
                 .background(Capsule().fill(.white))
@@ -62,7 +367,77 @@ private struct ChatBubble: View {
                 .fill(.white)
                 .frame(width: 12, height: 7)
         }
-        .fixedSize()
+        .fixedSize(horizontal: true, vertical: true)
+        .frame(maxWidth: 420)
+    }
+}
+
+// MARK: - State dot
+
+/// State dot with optional sonar pulse (working, waiting, done) or plain.
+private struct StateDot: View {
+    enum Style { case plain, pulse }
+
+    let color: Color
+    let style: Style
+
+    var body: some View {
+        Group {
+            switch style {
+            case .plain:
+                Circle().fill(color).frame(width: 6, height: 6)
+            case .pulse:
+                PulsingRingDot(color: color)
+            }
+        }
+        .frame(width: 14, height: 14)
+    }
+}
+
+private struct PulsingRingDot: View {
+    let color: Color
+    @State private var expanded = false
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(color, lineWidth: 1.5)
+                .frame(width: expanded ? 14 : 6, height: expanded ? 14 : 6)
+                .opacity(expanded ? 0 : 0.8)
+            Circle()
+                .fill(color)
+                .frame(width: 6, height: 6)
+        }
+        .onAppear {
+            withAnimation(.easeOut(duration: 0.9).repeatForever(autoreverses: false)) {
+                expanded = true
+            }
+        }
+    }
+}
+
+// MARK: - Waiting text flash
+
+/// Gently pulses row text opacity when waiting for input (no strikethrough).
+private struct WaitingTextFlash: ViewModifier {
+    let active: Bool
+    @State private var dimmed = false
+
+    func body(content: Content) -> some View {
+        content
+            .opacity(active ? (dimmed ? 0.4 : 1.0) : 1.0)
+            .onAppear { sync() }
+            .onChange(of: active) { _ in sync() }
+    }
+
+    private func sync() {
+        if active {
+            withAnimation(.easeInOut(duration: 1.1).repeatForever(autoreverses: true)) {
+                dimmed = true
+            }
+        } else {
+            dimmed = false
+        }
     }
 }
 

--- a/Sources/App/PetView.swift
+++ b/Sources/App/PetView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import AgentPetCore
 
@@ -71,11 +72,11 @@ struct FloatingPetView: View {
 
 // MARK: - Agent Bubble (structured rows for working/waiting)
 
-/// Sessions with the same agent kind + project are collapsed into one row.
+/// Sessions sharing an agent kind collapse into one row when enabled.
 private struct GroupedSession: Identifiable {
     let session: AgentSession   // highest-priority session in the group
-    let count: Int              // total sessions sharing this kind+project
-    var id: String { session.id }
+    let count: Int              // total sessions sharing this agent kind
+    var id: String { "\(session.agentKind.rawValue)-\(session.id)" }
 }
 
 /// Speech bubble listing one row per (agentKind, project) group.
@@ -97,9 +98,10 @@ struct AgentBubble: View {
             .filter { !settings.hiddenKinds.contains($0.agentKind) }
             .filter { settings.minStateFilter.includes($0.state) }
 
-        // 2. Sort
+        // 2. Sort (grouped mode always sorts by kind first)
         var sorted = filtered
-        if settings.groupByKind {
+        let sortByKind = settings.sessionGrouping == .byKind || settings.groupByKind
+        if sortByKind {
             sorted.sort {
                 if $0.agentKind.rawValue != $1.agentKind.rawValue {
                     return $0.agentKind.rawValue < $1.agentKind.rawValue
@@ -114,16 +116,16 @@ struct AgentBubble: View {
             }
         }
 
-        // 3. One row per session id. Collapse only exact duplicate ids (defensive).
+        // 3. Collapse by agent kind when grouped (highest-priority session per kind).
         var result: [GroupedSession]
-        if settings.collapseDuplicates {
-            var seen: [String: Int] = [:]
+        if settings.sessionGrouping == .byKind {
+            var seen: [AgentKind: Int] = [:]
             result = []
             for s in sorted {
-                if let idx = seen[s.id] {
+                if let idx = seen[s.agentKind] {
                     result[idx] = GroupedSession(session: result[idx].session, count: result[idx].count + 1)
                 } else {
-                    seen[s.id] = result.count
+                    seen[s.agentKind] = result.count
                     result.append(GroupedSession(session: s, count: 1))
                 }
             }
@@ -131,13 +133,22 @@ struct AgentBubble: View {
             result = sorted.map { GroupedSession(session: $0, count: 1) }
         }
 
-        // 4. Cap to maxSessions
+        // 4. Cap to maxSessions (list/compact); carousel shows all groups.
+        if settings.displayMode == .carousel {
+            return result
+        }
         return Array(result.prefix(settings.maxSessions))
     }
 
+    private var totalSessionCount: Int {
+        groupedSessions.reduce(0) { $0 + $1.count }
+    }
+
     private var isPetChat: Bool { tailEdge == .bottom }
-    // Use capsule only for a single-agent pet-chat bubble; switch to rounded rect for 2+ agents.
-    private var useCapsule: Bool { isPetChat && groupedSessions.count <= 1 }
+    // Capsule for single visible row; rounded rect when taller or carousel dots are shown.
+    private var useCapsule: Bool {
+        isPetChat && groupedSessions.count <= 1 && settings.displayMode != .compact
+    }
 
     var body: some View {
         let fill = isPetChat ? Color.white : bubbleFill
@@ -151,9 +162,7 @@ struct AgentBubble: View {
                     .scaleEffect(x: 1, y: -1)
             }
             VStack(alignment: .leading, spacing: isPetChat ? 4 : 5) {
-                ForEach(groupedSessions) { group in
-                    AgentRow(session: group.session, count: group.count, chatStyle: isPetChat)
-                }
+                bubbleContent
             }
             .padding(.horizontal, 12)
             .padding(.vertical, isPetChat ? 7 : 9)
@@ -201,6 +210,253 @@ struct AgentBubble: View {
         case .dark:   return .white.opacity(0.12)
         case .system: return Color.primary.opacity(0.08)
         }
+    }
+
+    @ViewBuilder
+    private var bubbleContent: some View {
+        switch settings.displayMode {
+        case .list:
+            ForEach(groupedSessions) { group in
+                AgentRow(session: group.session, count: group.count, chatStyle: isPetChat)
+            }
+        case .carousel:
+            BubbleCarousel(groups: groupedSessions, chatStyle: isPetChat)
+        case .compact:
+            BubbleCompactLayout(
+                groups: groupedSessions,
+                totalCount: totalSessionCount,
+                chatStyle: isPetChat,
+                textColor: textColor
+            )
+        }
+    }
+
+    private func textColor(_ opacity: Double) -> Color {
+        if isPetChat { return .black.opacity(opacity) }
+        switch settings.theme {
+        case .light:  return .black.opacity(opacity)
+        case .dark:   return .white.opacity(opacity)
+        case .system: return Color.primary.opacity(opacity)
+        }
+    }
+}
+
+// MARK: - Carousel (one agent at a time)
+
+private struct BubbleCarousel: View {
+    let groups: [GroupedSession]
+    var chatStyle: Bool = false
+    @State private var index = 0
+    @State private var timer: Timer?
+    @State private var dragOffset: CGFloat = 0
+
+    private static let interval: TimeInterval = 3.0
+    private static let swipeThreshold: CGFloat = 32
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: chatStyle ? 4 : 5) {
+            Group {
+                if let group = groups[safe: index] {
+                    AgentRow(session: group.session, count: group.count, chatStyle: chatStyle)
+                        .id(group.id)
+                        .transition(.opacity)
+                }
+            }
+            .offset(x: dragOffset)
+            .animation(.easeInOut(duration: 0.35), value: index)
+            .clipped()
+
+            if groups.count > 1 {
+                HStack(spacing: 4) {
+                    Spacer(minLength: 0)
+                    ForEach(0..<groups.count, id: \.self) { i in
+                        Circle()
+                            .fill(i == index ? dotActive : dotInactive)
+                            .frame(width: 4, height: 4)
+                    }
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+        .contentShape(Rectangle())
+        .background {
+            if groups.count > 1 {
+                HorizontalSwipeReader(
+                    onSwipeLeft: { step(by: 1) },
+                    onSwipeRight: { step(by: -1) }
+                )
+            }
+        }
+        .highPriorityGesture(swipeGesture)
+        .onAppear { syncTimer() }
+        .onDisappear { stopTimer() }
+        .onChange(of: groups.map(\.id)) { _ in
+            index = 0
+            dragOffset = 0
+            syncTimer()
+        }
+    }
+
+    private var swipeGesture: some Gesture {
+        DragGesture(minimumDistance: 12)
+            .onChanged { value in
+                guard groups.count > 1 else { return }
+                dragOffset = value.translation.width
+            }
+            .onEnded { value in
+                guard groups.count > 1 else {
+                    dragOffset = 0
+                    return
+                }
+                let tx = value.translation.width
+                if tx <= -Self.swipeThreshold {
+                    step(by: 1)
+                } else if tx >= Self.swipeThreshold {
+                    step(by: -1)
+                }
+                withAnimation(.easeOut(duration: 0.2)) { dragOffset = 0 }
+            }
+    }
+
+    private var dotActive: Color {
+        chatStyle ? .black.opacity(0.55) : Color.primary.opacity(0.7)
+    }
+
+    private var dotInactive: Color {
+        chatStyle ? .black.opacity(0.2) : Color.primary.opacity(0.25)
+    }
+
+    private func step(by delta: Int) {
+        guard groups.count > 1 else { return }
+        withAnimation(.easeInOut(duration: 0.35)) {
+            index = (index + delta + groups.count) % groups.count
+        }
+        syncTimer()
+    }
+
+    private func syncTimer() {
+        stopTimer()
+        guard groups.count > 1 else { return }
+        timer = Timer.scheduledTimer(withTimeInterval: Self.interval, repeats: true) { _ in
+            Task { @MainActor in step(by: 1) }
+        }
+    }
+
+    private func stopTimer() {
+        timer?.invalidate()
+        timer = nil
+    }
+}
+
+// MARK: - Trackpad horizontal swipe (scroll wheel)
+
+/// Captures two-finger horizontal trackpad swipes inside the carousel bubble.
+private struct HorizontalSwipeReader: NSViewRepresentable {
+    let onSwipeLeft: () -> Void
+    let onSwipeRight: () -> Void
+
+    func makeNSView(context: Context) -> HorizontalSwipeNSView {
+        let view = HorizontalSwipeNSView()
+        view.onSwipeLeft = onSwipeLeft
+        view.onSwipeRight = onSwipeRight
+        return view
+    }
+
+    func updateNSView(_ nsView: HorizontalSwipeNSView, context: Context) {
+        nsView.onSwipeLeft = onSwipeLeft
+        nsView.onSwipeRight = onSwipeRight
+    }
+}
+
+private final class HorizontalSwipeNSView: NSView {
+    var onSwipeLeft: (() -> Void)?
+    var onSwipeRight: (() -> Void)?
+    private var accumulatedX: CGFloat = 0
+    private var lastFireAt: TimeInterval = 0
+
+    override var acceptsFirstResponder: Bool { true }
+
+    override func scrollWheel(with event: NSEvent) {
+        guard abs(event.scrollingDeltaX) >= abs(event.scrollingDeltaY) else { return }
+
+        accumulatedX += event.scrollingDeltaX
+        let ended = event.phase == .ended || event.phase == .cancelled
+            || event.momentumPhase == .ended || event.momentumPhase == .cancelled
+        guard ended else { return }
+
+        let threshold: CGFloat = 28
+        if accumulatedX <= -threshold {
+            fireSwipe(left: true)
+        } else if accumulatedX >= threshold {
+            fireSwipe(left: false)
+        }
+        accumulatedX = 0
+    }
+
+    private func fireSwipe(left: Bool) {
+        let now = ProcessInfo.processInfo.systemUptime
+        guard now - lastFireAt > 0.35 else { return }
+        lastFireAt = now
+        Task { @MainActor in
+            if left { onSwipeLeft?() } else { onSwipeRight?() }
+        }
+    }
+}
+
+// MARK: - Compact (summary header + 2 rows + fold)
+
+private struct BubbleCompactLayout: View {
+    let groups: [GroupedSession]
+    let totalCount: Int
+    var chatStyle: Bool = false
+    let textColor: (Double) -> Color
+    @State private var expanded = false
+
+    private let visibleRows = 2
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: chatStyle ? 4 : 5) {
+            Text(summaryLabel)
+                .font(.system(size: chatStyle ? 10 : 10.5, weight: .semibold))
+                .foregroundStyle(textColor(0.45))
+
+            ForEach(visibleGroups) { group in
+                AgentRow(session: group.session, count: group.count, chatStyle: chatStyle)
+            }
+
+            if hiddenCount > 0 {
+                Button(action: { withAnimation(.easeInOut(duration: 0.2)) { expanded.toggle() } }) {
+                    Text(expanded ? "Show less" : "+\(hiddenCount) more")
+                        .font(.system(size: chatStyle ? 10 : 10.5, weight: .medium))
+                        .foregroundStyle(textColor(0.5))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .onChange(of: groups.map(\.id)) { _ in expanded = false }
+    }
+
+    private var summaryLabel: String {
+        let n = totalCount
+        let kinds = groups.count
+        if kinds <= 1 {
+            return "\(n) agent\(n == 1 ? "" : "s")"
+        }
+        return "\(n) agent\(n == 1 ? "" : "s") · \(kinds) kind\(kinds == 1 ? "" : "s")"
+    }
+
+    private var visibleGroups: [GroupedSession] {
+        expanded ? groups : Array(groups.prefix(visibleRows))
+    }
+
+    private var hiddenCount: Int {
+        max(0, groups.count - visibleRows)
+    }
+}
+
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
     }
 }
 

--- a/Sources/App/PetWindowController.swift
+++ b/Sources/App/PetWindowController.swift
@@ -14,11 +14,19 @@ final class PetWindowController: ObservableObject {
 
     private var panel: NSPanel?
     private var sizeCancellable: AnyCancellable?
+    private var chatLineCancellable: AnyCancellable?
     private var rightClickMonitor: Any?
     private var screenObserver: Any?
+    private var moveObserver: Any?
+
+    /// Screen position of the pet's bottom-center; kept stable across resizes.
+    private var anchorBottomCenter: NSPoint?
+    private var lastContentSize: CGSize = .zero
+    private var resizeDebounce: DispatchWorkItem?
 
     func start() {
-        let size = PetController.shared.windowSize
+        let pet = PetController.shared.petPoint
+        let size = CGSize(width: pet + 24, height: pet + 24)
         let panel = NSPanel(
             contentRect: NSRect(origin: .zero, size: size),
             styleMask: [.borderless, .nonactivatingPanel],
@@ -35,12 +43,24 @@ final class PetWindowController: ObservableObject {
         panel.contentView = ClickThroughHostingView(rootView: FloatingPetView())
         self.panel = panel
 
+        moveObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didMoveNotification, object: panel, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.syncAnchorFromWindow() }
+        }
+
         placeInitially(size: size)
+        syncAnchorFromWindow()
         applyVisibility(isVisible)
 
-        // On size change, resize in place (keep the pet where the user put it).
-        sizeCancellable = PetController.shared.$petPoint.sink { [weak self] point in
-            self?.resizeInPlace(to: PetController.windowSize(forPoint: point))
+        // On pet-size change, re-measure after SwiftUI relayouts.
+        sizeCancellable = PetController.shared.$petPoint.sink { [weak self] _ in
+            self?.remeasureContent()
+        }
+
+        // On agent rows added/removed, re-measure after SwiftUI relayouts.
+        chatLineCancellable = PetController.shared.$chatLineCount.sink { [weak self] _ in
+            self?.remeasureContent()
         }
 
         // If displays change (e.g. a monitor is unplugged), keep the pet on screen.
@@ -72,13 +92,53 @@ final class PetWindowController: ObservableObject {
         panel.setFrame(NSRect(origin: origin, size: size), display: true, animate: false)
     }
 
-    /// Resizes around the pet's bottom-center so it stays where the user
-    /// dragged it, clamped to whichever screen it currently sits on.
+    /// Sizes the panel to hug the pet + bubble content.
+    func resizeToContent(_ size: CGSize) {
+        guard size.width > 0, size.height > 0 else { return }
+
+        resizeDebounce?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            self?.applyContentResize(size)
+        }
+        resizeDebounce = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05, execute: work)
+    }
+
+    private func applyContentResize(_ size: CGSize) {
+        let padded = CGSize(width: size.width + 4, height: size.height + 4)
+        let dw = abs(padded.width - lastContentSize.width)
+        let dh = abs(padded.height - lastContentSize.height)
+        guard dw > 1 || dh > 1 || lastContentSize == .zero else { return }
+        lastContentSize = padded
+        resizeInPlace(to: padded)
+    }
+
+    private func remeasureContent() {
+        DispatchQueue.main.async { [weak self] in
+            guard let host = self?.panel?.contentView as? NSHostingView<FloatingPetView> else { return }
+            host.invalidateIntrinsicContentSize()
+            host.layoutSubtreeIfNeeded()
+            let size = host.fittingSize
+            guard size.width > 0, size.height > 0 else { return }
+            self?.resizeToContent(size)
+        }
+    }
+
+    private func syncAnchorFromWindow() {
+        guard let panel else { return }
+        let frame = panel.frame
+        anchorBottomCenter = NSPoint(x: frame.midX, y: frame.minY)
+    }
+
+    /// Resizes around a fixed bottom-center anchor so the pet doesn't drift.
     private func resizeInPlace(to size: CGSize) {
         guard let panel else { return }
-        let old = panel.frame
-        var origin = NSPoint(x: old.midX - size.width / 2, y: old.minY)
-        if let visible = currentScreen(for: old)?.visibleFrame {
+        if anchorBottomCenter == nil { syncAnchorFromWindow() }
+        guard let anchor = anchorBottomCenter else { return }
+
+        var origin = NSPoint(x: anchor.x - size.width / 2, y: anchor.y)
+        let probe = NSRect(origin: origin, size: size)
+        if let visible = currentScreen(for: probe)?.visibleFrame {
             origin.x = min(max(origin.x, visible.minX), visible.maxX - size.width)
             origin.y = min(max(origin.y, visible.minY), visible.maxY - size.height)
         }
@@ -94,6 +154,7 @@ final class PetWindowController: ObservableObject {
         guard let visible = NSScreen.main?.visibleFrame else { return }
         let origin = NSPoint(x: visible.maxX - frame.width - 16, y: visible.minY + 24)
         panel.setFrameOrigin(origin)
+        syncAnchorFromWindow()
     }
 
     /// The screen whose frame contains the window's center, if any.

--- a/Sources/App/SettingsModel.swift
+++ b/Sources/App/SettingsModel.swift
@@ -68,6 +68,46 @@ final class SettingsModel: ObservableObject {
         }
     }
 
+    /// Repairs hook entries whose embedded binary path no longer matches the
+    /// current executable location. Runs on every launch so hooks stay valid
+    /// after the app is moved, re-downloaded, or updated via a different channel
+    /// (e.g. Homebrew vs DMG).  Idempotent — only rewrites when the path differs.
+    func repairStaleHookPathsIfNeeded() {
+        let currentPath = Bundle.main.executablePath ?? ""
+        guard !currentPath.isEmpty else { return }
+        let expectedCommand = "\"\(currentPath)\" hook"
+        for agent in agents where agent.isSupported {
+            guard let spec = AgentHooks.spec(for: agent.kind) else { continue }
+            guard let settings = try? HookInstaller.readSettings(path: spec.settingsPath) else { continue }
+            guard HookInstaller.isInstalledOnDisk(path: spec.settingsPath,
+                                                  events: spec.events,
+                                                  style: spec.style) else { continue }
+            // Check if any stored hook command references a different binary path.
+            let needsRepair: Bool = {
+                guard let hooks = settings["hooks"] as? [String: Any] else { return false }
+                for event in spec.events {
+                    guard let groups = hooks[event] as? [[String: Any]] else { continue }
+                    for group in groups {
+                        guard let inner = group["hooks"] as? [[String: Any]] else { continue }
+                        for entry in inner {
+                            if let cmd = entry["command"] as? String,
+                               cmd.contains("agentpet") && cmd.contains("hook"),
+                               !cmd.hasPrefix(expectedCommand) {
+                                return true
+                            }
+                        }
+                    }
+                }
+                return false
+            }()
+            guard needsRepair else { continue }
+            try? HookInstaller.installToDisk(command: hookCommand(for: agent.kind),
+                                             path: spec.settingsPath,
+                                             events: spec.events,
+                                             style: spec.style)
+        }
+    }
+
     private func hookCommand(for kind: AgentKind) -> String {
         let path = Bundle.main.executablePath ?? CommandLine.arguments.first ?? "agentpet"
         return "\"\(path)\" hook --agent \(kind.rawValue)"

--- a/Sources/App/SetupView.swift
+++ b/Sources/App/SetupView.swift
@@ -9,7 +9,7 @@ struct SetupView: View {
     @ObservedObject private var imagePets = ImagePetStore.shared
     var onClose: () -> Void
 
-    enum Tab { case general, pet, about }
+    enum Tab { case general, pet, bubble, about }
     @State private var tab: Tab = .general
 
     private var selectedPack: ImagePetPack? {
@@ -26,6 +26,8 @@ struct SetupView: View {
                     GeneralTab(model: model, pet: pet)
                 case .pet:
                     PetTab(pet: pet, imagePets: imagePets, model: model, selectedPack: selectedPack)
+                case .bubble:
+                    BubbleSettingsView()
                 case .about:
                     AboutTab()
                 }
@@ -41,6 +43,7 @@ struct SetupView: View {
         HStack(spacing: 8) {
             TabButton(icon: "gearshape.fill", label: "General", selected: tab == .general) { tab = .general }
             TabButton(icon: "pawprint.fill", label: "Pet", selected: tab == .pet) { tab = .pet }
+            TabButton(icon: "bubble.left.and.bubble.right.fill", label: "Bubble", selected: tab == .bubble) { tab = .bubble }
             TabButton(icon: "heart.fill", label: "About", selected: tab == .about) { tab = .about }
         }
         .frame(maxWidth: .infinity)

--- a/Sources/App/SetupView.swift
+++ b/Sources/App/SetupView.swift
@@ -179,7 +179,6 @@ private struct SoundRow: View {
 private struct GeneralTab: View {
     @ObservedObject var model: SettingsModel
     @ObservedObject var pet: PetController
-    @ObservedObject private var chat = ChatSettings.shared
     @ObservedObject private var sound = SoundSettings.shared
     // Local mirror of the system login-item state so the toggle re-renders
     // reliably (the SMAppService status isn't observable on its own).
@@ -212,41 +211,6 @@ private struct GeneralTab: View {
                     }
                     Spacer()
                     notificationButton
-                }
-            }
-
-            Section("Pet chat") {
-                HStack {
-                    Text("Show chat bubble")
-                    Spacer()
-                    ColorSwitch(isOn: $pet.showChat)
-                }
-                Picker("Messages", selection: $chat.source) {
-                    Text("System").tag(ChatSettings.Source.system)
-                    Text("Custom").tag(ChatSettings.Source.custom)
-                }
-                .pickerStyle(.segmented)
-                if chat.source == .custom {
-                    ForEach(ChatSettings.editableMoods, id: \.self) { mood in
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(moodLabel(mood)).font(.caption).foregroundStyle(.secondary)
-                            GrowingTextEditor(text: Binding(
-                                get: { chat.text(for: mood) },
-                                set: { chat.setText($0, for: mood) }
-                            ))
-                            .padding(4)
-                            .background(RoundedRectangle(cornerRadius: 6).fill(Color(white: 0.16)))
-                            .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(.white.opacity(0.12)))
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-                    }
-                    HStack {
-                        Text("One message per line; a random one is shown.")
-                            .font(.caption).foregroundStyle(.secondary)
-                        Spacer()
-                        Button("Reset to defaults") { chat.resetToDefaults() }
-                            .controlSize(.small)
-                    }
                 }
             }
 
@@ -302,15 +266,7 @@ private struct GeneralTab: View {
         .formStyle(.grouped)
     }
 
-    private func moodLabel(_ mood: PetMood) -> String {
-        switch mood {
-        case .working: return "Working"
-        case .waiting: return "Waiting"
-        case .done: return "Done"
-        case .celebrate: return "Celebrate"
-        case .idle: return "Idle"
-        }
-    }
+
 
     private var appVersion: String {
         let v = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.1.0"

--- a/Sources/App/StatusBarController.swift
+++ b/Sources/App/StatusBarController.swift
@@ -27,10 +27,19 @@ final class StatusBarController: NSObject, ObservableObject {
             updateStatus(lastSessions)
         }
     }
+    /// Whether to show the agent bubble (same as the floating pet) hanging below
+    /// the menu bar icon.
+    @Published var showBubbleOnMenuBar: Bool {
+        didSet {
+            UserDefaults.standard.set(showBubbleOnMenuBar, forKey: "agentpet.showBubbleMenuBar")
+            refreshAgentBubble()
+        }
+    }
 
     override init() {
         showCount = (UserDefaults.standard.object(forKey: "agentpet.showCount") as? Bool) ?? true
         showChatOnMenuBar = (UserDefaults.standard.object(forKey: "agentpet.showChatMenuBar") as? Bool) ?? false
+        showBubbleOnMenuBar = (UserDefaults.standard.object(forKey: "agentpet.showBubbleMenuBar") as? Bool) ?? false
         super.init()
     }
 
@@ -92,6 +101,7 @@ final class StatusBarController: NSObject, ObservableObject {
         }
 
         refreshChatBubble()
+        refreshAgentBubble()
     }
 
     /// Builds the menu bar image: the paw alone, or the paw plus a count laid out
@@ -183,11 +193,97 @@ final class StatusBarController: NSObject, ObservableObject {
         lastShownChat = ""
     }
 
+    // MARK: - Agent bubble hanging from menu bar
+
+    private var agentBubblePanel: NSPanel?
+    /// Holds the hosting controller so SwiftUI's @ObservedObject subscriptions
+    /// stay alive and the view auto-updates without recreating the panel.
+    private var agentBubbleHost: NSHostingView<AnyView>?
+
+    private func refreshAgentBubble() {
+        guard showBubbleOnMenuBar, !popover.isShown else {
+            hideAgentBubble()
+            return
+        }
+        let sessions = PetController.shared.activeAgentSessions
+        guard !sessions.isEmpty else {
+            hideAgentBubble()
+            return
+        }
+        positionAgentBubble()
+    }
+
+    private func positionAgentBubble() {
+        guard let button = statusItem?.button,
+              let buttonWindow = button.window else { return }
+
+        // Create the panel and a self-updating SwiftUI view once; reuse forever.
+        if agentBubblePanel == nil {
+            let panel = NSPanel(
+                contentRect: .zero,
+                styleMask: [.borderless, .nonactivatingPanel],
+                backing: .buffered,
+                defer: false
+            )
+            panel.level = .popUpMenu
+            panel.isOpaque = false
+            panel.backgroundColor = .clear
+            panel.hasShadow = false
+            panel.ignoresMouseEvents = true
+            panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+
+            // MenuBarBubbleView observes PetController directly so it refreshes
+            // automatically whenever sessions change.
+            let host = NSHostingView(rootView: AnyView(MenuBarBubbleView()))
+            agentBubbleHost = host
+            panel.contentView = host
+            agentBubblePanel = panel
+        }
+
+        // Re-fit and reposition on every call (window could have moved).
+        if let host = agentBubbleHost {
+            host.setFrameSize(host.fittingSize)
+        }
+        let size = agentBubbleHost?.fittingSize ?? CGSize(width: 300, height: 60)
+        agentBubblePanel?.setContentSize(size)
+
+        let btnFrame = buttonWindow.convertToScreen(button.convert(button.bounds, to: nil))
+        let originX = btnFrame.midX - size.width / 2
+        let originY = btnFrame.minY - size.height - 4
+        agentBubblePanel?.setFrameOrigin(NSPoint(x: originX, y: originY))
+        agentBubblePanel?.orderFrontRegardless()
+    }
+
+    private func hideAgentBubble() {
+        agentBubblePanel?.orderOut(nil)
+    }
+
     /// Shows the same popover anchored to an arbitrary view (e.g. the floating
     /// pet on right-click).
     func showPopover(relativeTo rect: NSRect, of view: NSView, edge: NSRectEdge) {
         if popover.isShown { popover.performClose(nil) }
         popover.show(relativeTo: rect, of: view, preferredEdge: edge)
+    }
+
+    // MARK: - Deferred close actions
+
+    /// Action to run once the popover finishes its close animation.
+    /// Use this instead of `DispatchQueue.main.asyncAfter` so the action fires
+    /// at the exact moment the popover delegate confirms it is closed.
+    private var pendingCloseAction: (() -> Void)?
+
+    /// Closes the popover and invokes `action` only after the close animation
+    /// has fully completed (via `NSPopoverDelegate.popoverDidClose`).
+    func closeAndThen(_ action: @escaping () -> Void) {
+        pendingCloseAction = action
+        if popover.isShown {
+            popover.performClose(nil)
+        } else {
+            // Already closed — fire immediately.
+            let pending = pendingCloseAction
+            pendingCloseAction = nil
+            pending?()
+        }
     }
 }
 
@@ -196,6 +292,8 @@ extension StatusBarController: NSPopoverDelegate {
         outsideClickMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { [weak self] _ in
             self?.popover.performClose(nil)
         }
+        // Hide the bubble while the full popover is open — they'd overlap.
+        hideAgentBubble()
     }
 
     func popoverDidClose(_ notification: Notification) {
@@ -203,5 +301,11 @@ extension StatusBarController: NSPopoverDelegate {
             NSEvent.removeMonitor(monitor)
             outsideClickMonitor = nil
         }
+        // Restore bubble after popover closes.
+        refreshAgentBubble()
+        // Fire any deferred action now that the close animation has finished.
+        let pending = pendingCloseAction
+        pendingCloseAction = nil
+        pending?()
     }
 }

--- a/Sources/App/UpdaterController.swift
+++ b/Sources/App/UpdaterController.swift
@@ -8,18 +8,66 @@ import Sparkle
 final class UpdaterController: NSObject, ObservableObject {
     static let shared = UpdaterController()
 
-    private let controller: SPUStandardUpdaterController
+    /// True while an update has been downloaded and is waiting to install.
+    /// The menu bar footer "Updates" button can observe this to show a badge.
+    @Published private(set) var updatePending = false
+
+    // lazy so `self` is valid when SPUStandardUpdaterController captures the
+    // delegate reference. init() triggers the lazy body immediately after
+    // super.init() so the updater's background timer starts on first launch.
+    private lazy var controller: SPUStandardUpdaterController = {
+        SPUStandardUpdaterController(startingUpdater: true,
+                                     updaterDelegate: self,
+                                     userDriverDelegate: nil)
+    }()
 
     override init() {
-        // startingUpdater: true wires automatic background checks immediately.
-        controller = SPUStandardUpdaterController(startingUpdater: true,
-                                                  updaterDelegate: nil,
-                                                  userDriverDelegate: nil)
         super.init()
+        _ = controller  // trigger lazy init now that self is live
     }
 
     /// User-initiated check (shows "you're up to date" if nothing is newer).
     func checkForUpdates() {
         controller.updater.checkForUpdates()
+    }
+}
+
+// MARK: - SPUUpdaterDelegate
+
+extension UpdaterController: SPUUpdaterDelegate {
+    /// Silently absorbs background-check errors (network offline, appcast
+    /// unreachable, etc.) so they never surface as unexpected alerts.
+    nonisolated func updater(_ updater: SPUUpdater, didAbortWithError error: Error) {
+        let ns = error as NSError
+        // SUNoUpdateError (1000) and user-cancellation (1001) are not real failures.
+        guard ns.domain == "SUSparkleErrorDomain" && (ns.code == 1000 || ns.code == 1001) else {
+            print("[AgentPet] Update check aborted (\(ns.domain) \(ns.code)): \(error.localizedDescription)")
+            return
+        }
+    }
+
+    /// Mark a pending update so the UI can show a badge.
+    nonisolated func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
+        Task { @MainActor [weak self] in self?.updatePending = true }
+    }
+
+    /// Clear the badge once an update is dismissed or applied.
+    nonisolated func updaterDidNotFindUpdate(_ updater: SPUUpdater) {
+        Task { @MainActor [weak self] in self?.updatePending = false }
+    }
+
+    /// Warn via notification if an update restarts the app while agents are active,
+    /// so users understand why sessions disappeared.
+    nonisolated func updaterWillRelaunchApplication(_ updater: SPUUpdater) {
+        Task { @MainActor in
+            let busy = AppDaemon.shared.sessions.contains {
+                $0.state == .working || $0.state == .waiting
+            }
+            guard busy else { return }
+            NotificationManager.shared.notify(
+                title: "AgentPet Updated",
+                body: "Active agent sessions were cleared because the app restarted to apply an update."
+            )
+        }
     }
 }

--- a/Tests/AgentPetAppTests/BubbleSettingsTests.swift
+++ b/Tests/AgentPetAppTests/BubbleSettingsTests.swift
@@ -15,10 +15,10 @@ final class BubbleSettingsTests: XCTestCase {
         super.tearDown()
     }
 
-    func testMultiAgentBubbleDefaultsOff() {
+    func testMultiAgentBubbleDefaultsOn() {
         let settings = BubbleSettings()
 
-        XCTAssertFalse(settings.multiAgentBubbleEnabled)
+        XCTAssertTrue(settings.multiAgentBubbleEnabled)
     }
 
     func testMultiAgentBubblePersists() {

--- a/Tests/AgentPetAppTests/BubbleSettingsTests.swift
+++ b/Tests/AgentPetAppTests/BubbleSettingsTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import agentpet
+
+@MainActor
+final class BubbleSettingsTests: XCTestCase {
+    private let multiAgentBubbleKey = "agentpet.bubble.multiAgentBubbleEnabled"
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: multiAgentBubbleKey)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: multiAgentBubbleKey)
+        super.tearDown()
+    }
+
+    func testMultiAgentBubbleDefaultsOff() {
+        let settings = BubbleSettings()
+
+        XCTAssertFalse(settings.multiAgentBubbleEnabled)
+    }
+
+    func testMultiAgentBubblePersists() {
+        let settings = BubbleSettings()
+
+        settings.multiAgentBubbleEnabled = true
+
+        XCTAssertTrue(BubbleSettings().multiAgentBubbleEnabled)
+    }
+}

--- a/Tests/AgentPetAppTests/BubbleSettingsTests.swift
+++ b/Tests/AgentPetAppTests/BubbleSettingsTests.swift
@@ -4,14 +4,20 @@ import XCTest
 @MainActor
 final class BubbleSettingsTests: XCTestCase {
     private let multiAgentBubbleKey = "agentpet.bubble.multiAgentBubbleEnabled"
+    private let sessionGroupingKey = "agentpet.bubble.sessionGrouping"
+    private let collapseDuplicatesKey = "agentpet.bubble.collapseDuplicates"
 
     override func setUp() {
         super.setUp()
         UserDefaults.standard.removeObject(forKey: multiAgentBubbleKey)
+        UserDefaults.standard.removeObject(forKey: sessionGroupingKey)
+        UserDefaults.standard.removeObject(forKey: collapseDuplicatesKey)
     }
 
     override func tearDown() {
         UserDefaults.standard.removeObject(forKey: multiAgentBubbleKey)
+        UserDefaults.standard.removeObject(forKey: sessionGroupingKey)
+        UserDefaults.standard.removeObject(forKey: collapseDuplicatesKey)
         super.tearDown()
     }
 
@@ -27,5 +33,20 @@ final class BubbleSettingsTests: XCTestCase {
         settings.multiAgentBubbleEnabled = true
 
         XCTAssertTrue(BubbleSettings().multiAgentBubbleEnabled)
+    }
+
+    func testSessionGroupingDefaultsToByKind() {
+        XCTAssertEqual(BubbleSettings().sessionGrouping, .byKind)
+    }
+
+    func testSessionGroupingPersists() {
+        let settings = BubbleSettings()
+        settings.sessionGrouping = .allSessions
+        XCTAssertEqual(BubbleSettings().sessionGrouping, .allSessions)
+    }
+
+    func testSessionGroupingMigratesFromLegacyCollapseOff() {
+        UserDefaults.standard.set(false, forKey: collapseDuplicatesKey)
+        XCTAssertEqual(BubbleSettings().sessionGrouping, .allSessions)
     }
 }

--- a/Tests/AgentPetAppTests/IdleBoostTests.swift
+++ b/Tests/AgentPetAppTests/IdleBoostTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import agentpet
+
+final class IdleBoostTests: XCTestCase {
+    func testLinesKeepPolishedDeveloperTone() {
+        XCTAssertTrue(IdleBoost.lines.contains("Let's grill some bugs."))
+        XCTAssertTrue(IdleBoost.lines.contains("I miss you. Open a branch for me."))
+        XCTAssertTrue(IdleBoost.lines.contains("Tiny commit, tiny dopamine."))
+    }
+
+    func testLinesAvoidNoisyPunctuationAndEmoji() {
+        for line in IdleBoost.lines {
+            XCTAssertFalse(line.contains("!"), line)
+            XCTAssertTrue(line.allSatisfy(\.isASCII), line)
+        }
+    }
+
+    func testLineSelectionIsStableInsideSameMinute() {
+        let now = Date(timeIntervalSince1970: 120)
+
+        XCTAssertEqual(
+            IdleBoost.line(at: now),
+            IdleBoost.line(at: now.addingTimeInterval(59))
+        )
+    }
+
+    func testLineSelectionRotatesAcrossMinutes() {
+        let first = IdleBoost.line(at: Date(timeIntervalSince1970: 0))
+        let later = IdleBoost.line(at: Date(timeIntervalSince1970: 60))
+
+        XCTAssertNotEqual(first, later)
+    }
+}

--- a/Tests/AgentPetCoreTests/ClaudeActivityFormatterTests.swift
+++ b/Tests/AgentPetCoreTests/ClaudeActivityFormatterTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+@testable import AgentPetCore
+
+final class ClaudeActivityFormatterTests: XCTestCase {
+
+    // MARK: - Rotation
+
+    func test_rotation_doesNotRepeatConsecutively() {
+        let first = ClaudeActivityFormatter.activityMessage(
+            eventName: "PreToolUse", sessionId: "rot1",
+            toolName: "Read", toolInput: nil, explicitMessage: nil
+        )
+        let second = ClaudeActivityFormatter.activityMessage(
+            eventName: "PreToolUse", sessionId: "rot1",
+            toolName: "Read", toolInput: nil, explicitMessage: nil
+        )
+        XCTAssertNotEqual(first, second, "consecutive calls same tool should rotate")
+    }
+
+    func test_rotation_cyclesFullPool() {
+        // reading pool has 5 phrases — 5 distinct calls must yield 5 distinct phrases
+        let poolSize = 5
+        var seen = Set<String?>()
+        for _ in 0..<poolSize {
+            let msg = ClaudeActivityFormatter.activityMessage(
+                eventName: "PreToolUse", sessionId: "rot2",
+                toolName: "Read", toolInput: nil, explicitMessage: nil
+            )
+            seen.insert(msg)
+        }
+        XCTAssertEqual(seen.count, poolSize, "should cycle through all \(poolSize) reading phrases")
+    }
+
+    // MARK: - Extension hints
+
+    func test_extensionHint_testFile_reading() {
+        let input = ClaudeToolInput(filePath: "Tests/FooTests/BarTests.swift")
+        let msg = ClaudeActivityFormatter.activityMessage(
+            eventName: "PreToolUse", sessionId: "ext1",
+            toolName: "Read", toolInput: input, explicitMessage: nil
+        )
+        XCTAssertEqual(msg, "Reviewing tests…")
+    }
+
+    func test_extensionHint_testFile_writing() {
+        let input = ClaudeToolInput(filePath: "Tests/FooTests/BarTests.swift")
+        let msg = ClaudeActivityFormatter.activityMessage(
+            eventName: "PreToolUse", sessionId: "ext2",
+            toolName: "Edit", toolInput: input, explicitMessage: nil
+        )
+        XCTAssertEqual(msg, "Refining tests…")
+    }
+
+    func test_extensionHint_markdown_reading() {
+        let input = ClaudeToolInput(filePath: "README.md")
+        let msg = ClaudeActivityFormatter.activityMessage(
+            eventName: "PreToolUse", sessionId: "ext3",
+            toolName: "Read", toolInput: input, explicitMessage: nil
+        )
+        XCTAssertEqual(msg, "Reading the docs…")
+    }
+
+    func test_extensionHint_markdown_writing() {
+        let input = ClaudeToolInput(filePath: "docs/guide.md")
+        let msg = ClaudeActivityFormatter.activityMessage(
+            eventName: "PreToolUse", sessionId: "ext4",
+            toolName: "Write", toolInput: input, explicitMessage: nil
+        )
+        XCTAssertEqual(msg, "Updating the docs…")
+    }
+
+    func test_extensionHint_json_reading() {
+        let input = ClaudeToolInput(filePath: "config/settings.json")
+        let msg = ClaudeActivityFormatter.activityMessage(
+            eventName: "PreToolUse", sessionId: "ext5",
+            toolName: "Read", toolInput: input, explicitMessage: nil
+        )
+        XCTAssertEqual(msg, "Parsing config…")
+    }
+
+    func test_extensionHint_plist_writing() {
+        let input = ClaudeToolInput(filePath: "Info.plist")
+        let msg = ClaudeActivityFormatter.activityMessage(
+            eventName: "PreToolUse", sessionId: "ext6",
+            toolName: "Edit", toolInput: input, explicitMessage: nil
+        )
+        XCTAssertEqual(msg, "Adjusting config…")
+    }
+
+    // MARK: - State messages
+
+    func test_stateMessage_done_returnsPhrase() {
+        XCTAssertNotNil(ClaudeActivityFormatter.stateMessage(for: .done))
+    }
+
+    func test_stateMessage_waiting_returnsPhrase() {
+        XCTAssertNotNil(ClaudeActivityFormatter.stateMessage(for: .waiting))
+    }
+
+    func test_stateMessage_idle_returnsNil() {
+        XCTAssertNil(ClaudeActivityFormatter.stateMessage(for: .idle))
+    }
+
+    func test_stateMessage_working_returnsNil() {
+        XCTAssertNil(ClaudeActivityFormatter.stateMessage(for: .working))
+    }
+
+    func test_stateMessage_done_rotates() {
+        let first  = ClaudeActivityFormatter.stateMessage(for: .done)
+        let second = ClaudeActivityFormatter.stateMessage(for: .done)
+        XCTAssertNotEqual(first, second, "done phrases should rotate")
+    }
+}

--- a/Tests/AgentPetCoreTests/QuestionDetectorTests.swift
+++ b/Tests/AgentPetCoreTests/QuestionDetectorTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import AgentPetCore
+
+final class QuestionDetectorTests: XCTestCase {
+    func testEndsWithQuestionMark() {
+        XCTAssertTrue(QuestionDetector.looksLikeQuestion("Which approach do you prefer, A or B?"))
+    }
+
+    func testTrailingWhitespaceAfterQuestionMarkStillDetected() {
+        XCTAssertTrue(QuestionDetector.looksLikeQuestion("Want me to push this too?  \n"))
+    }
+
+    func testRequestForDirectionPhraseWithoutQuestionMark() {
+        XCTAssertTrue(QuestionDetector.looksLikeQuestion(
+            "I've made the change. Let me know if you'd like any tweaks."))
+        XCTAssertTrue(QuestionDetector.looksLikeQuestion(
+            "Should I go ahead and run the migration now"))
+    }
+
+    func testPlainCompletionStatementIsNotAQuestion() {
+        XCTAssertFalse(QuestionDetector.looksLikeQuestion(
+            "Done — fixed the login bug and added a regression test."))
+    }
+
+    func testEmptyAndWhitespaceOnlyAreNotQuestions() {
+        XCTAssertFalse(QuestionDetector.looksLikeQuestion(""))
+        XCTAssertFalse(QuestionDetector.looksLikeQuestion("   \n  "))
+    }
+}

--- a/Tests/AgentPetCoreTests/SessionStoreTests.swift
+++ b/Tests/AgentPetCoreTests/SessionStoreTests.swift
@@ -86,6 +86,41 @@ final class SessionStoreTests: XCTestCase {
         XCTAssertEqual(store.sessions.count, 0)
     }
 
+    func testRefineStateAppliesWhenStateAndSinceStillMatch() {
+        let store = SessionStore()
+        let applied = store.apply(event("Stop"), now: t0)
+        XCTAssertEqual(applied?.state, .done)
+
+        store.refineState(id: "s1", from: .done, to: .waiting, since: applied!.stateSince)
+
+        let refined = store.session(id: "s1")
+        XCTAssertEqual(refined?.state, .waiting)
+        XCTAssertEqual(refined?.stateSince, applied!.stateSince,
+                       "correction preserves the original transition time")
+    }
+
+    func testRefineStateNoOpsWhenANewerEventAlreadyChangedState() {
+        let store = SessionStore()
+        let applied = store.apply(event("Stop"), now: t0)
+        store.apply(event("UserPromptSubmit"), now: t0.addingTimeInterval(2))   // user replied -> working
+
+        store.refineState(id: "s1", from: .done, to: .waiting, since: applied!.stateSince)
+
+        XCTAssertEqual(store.session(id: "s1")?.state, .working,
+                       "a newer transition must never be clobbered by a stale correction")
+    }
+
+    func testRefineStateNoOpsWhenSinceNoLongerMatches() {
+        let store = SessionStore()
+        let applied = store.apply(event("Stop"), now: t0)
+        let staleSince = applied!.stateSince.addingTimeInterval(-10)
+
+        store.refineState(id: "s1", from: .done, to: .waiting, since: staleSince)
+
+        XCTAssertEqual(store.session(id: "s1")?.state, .done,
+                       "a `since` mismatch means this correction targets a transition that's gone")
+    }
+
     func testPruneDemotesDoneToIdle() {
         let store = SessionStore(doneToIdleAfter: 30, removeIdleAfter: 600)
         store.apply(event("Stop"), now: t0)

--- a/Tests/AgentPetCoreTests/SessionStoreTests.swift
+++ b/Tests/AgentPetCoreTests/SessionStoreTests.swift
@@ -9,7 +9,8 @@ final class StateMapperTests: XCTestCase {
         XCTAssertEqual(StateMapper.state(for: .claude, eventName: "PostToolUse"), .working)
         XCTAssertEqual(StateMapper.state(for: .claude, eventName: "Notification"), .waiting)
         XCTAssertEqual(StateMapper.state(for: .claude, eventName: "Stop"), .done)
-        XCTAssertEqual(StateMapper.state(for: .claude, eventName: "SubagentStop"), .done)
+        XCTAssertNil(StateMapper.state(for: .claude, eventName: "SubagentStop"),
+                     "a subagent finishing mid-task must not change the main session's state")
     }
 
     func testUnknownEventIsIgnored() {
@@ -38,10 +39,16 @@ final class StateMapperTests: XCTestCase {
     }
 
     func testHookSpecsCoverInstallEvents() {
-        // Every event we register must either map to a state or end the session.
+        // Every event we register must either map to a state, end the session,
+        // or be an intentionally-ignored event (documented here).
+        let intentionallyIgnored: [AgentKind: Set<String>] = [
+            .claude: ["SubagentStop"]
+        ]
         for kind in [AgentKind.claude, .codex, .gemini] {
             let spec = AgentHooks.spec(for: kind)!
-            for event in spec.events where !StateMapper.isSessionEnd(for: kind, eventName: event) {
+            let ignored = intentionallyIgnored[kind] ?? []
+            for event in spec.events
+            where !StateMapper.isSessionEnd(for: kind, eventName: event) && !ignored.contains(event) {
                 XCTAssertNotNil(StateMapper.state(for: kind, eventName: event), "\(kind) \(event)")
             }
         }

--- a/Tests/AgentPetCoreTests/TickerFormatterTests.swift
+++ b/Tests/AgentPetCoreTests/TickerFormatterTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import AgentPetCore
+
+final class TickerFormatterTests: XCTestCase {
+
+    // MARK: agentLabel
+
+    func testAgentLabelKnownKinds() {
+        XCTAssertEqual(TickerFormatter.agentLabel(for: .claude),   "Claude")
+        XCTAssertEqual(TickerFormatter.agentLabel(for: .cursor),   "Cursor")
+        XCTAssertEqual(TickerFormatter.agentLabel(for: .codex),    "Codex")
+        XCTAssertEqual(TickerFormatter.agentLabel(for: .gemini),   "Gemini")
+        XCTAssertEqual(TickerFormatter.agentLabel(for: .opencode), "Opencode")
+        XCTAssertEqual(TickerFormatter.agentLabel(for: .windsurf), "Windsurf")
+    }
+
+    func testAgentLabelFallbacks() {
+        XCTAssertEqual(TickerFormatter.agentLabel(for: .cli),     "Agent")
+        XCTAssertEqual(TickerFormatter.agentLabel(for: .unknown), "Agent")
+    }
+
+    // MARK: line(for:)
+
+    func testLineWithMessage() {
+        let session = AgentSession(
+            id: "claude-abc",
+            agentKind: .claude,
+            project: "/Users/me/agentpet",
+            state: .working,
+            message: "running bash…",
+            source: .hook,
+            updatedAt: Date()
+        )
+        XCTAssertEqual(TickerFormatter.line(for: session), "Claude [agentpet] → running bash…")
+    }
+
+    func testLineWithoutMessage() {
+        let session = AgentSession(
+            id: "cursor-xyz",
+            agentKind: .cursor,
+            project: "/Users/me/my-api",
+            state: .waiting,
+            message: nil,
+            source: .hook,
+            updatedAt: Date()
+        )
+        XCTAssertEqual(TickerFormatter.line(for: session), "Cursor [my-api] → Waiting")
+    }
+
+    func testLineWithWhitespaceOnlyMessage() {
+        let session = AgentSession(
+            id: "gemini-1",
+            agentKind: .gemini,
+            project: "/Users/me/frontend",
+            state: .working,
+            message: "   ",
+            source: .hook,
+            updatedAt: Date()
+        )
+        XCTAssertEqual(TickerFormatter.line(for: session), "Gemini [frontend] → Working")
+    }
+
+    func testLineFallsBackToIdWhenNoProject() {
+        let session = AgentSession(
+            id: "my-session-id",
+            agentKind: .cli,
+            project: nil,
+            state: .working,
+            message: "running",
+            source: .hook,
+            updatedAt: Date()
+        )
+        XCTAssertEqual(TickerFormatter.line(for: session), "Agent [my-session-id] → running")
+    }
+
+    // MARK: sorted(_:)
+
+    func testSortedWaitingFirst() {
+        let t = Date()
+        let working = AgentSession(id: "a", agentKind: .claude, state: .working, source: .hook, updatedAt: t)
+        let waiting = AgentSession(id: "b", agentKind: .cursor, state: .waiting, source: .hook, updatedAt: t)
+        let done    = AgentSession(id: "c", agentKind: .codex,  state: .done,    source: .hook, updatedAt: t)
+
+        let result = TickerFormatter.sorted([done, working, waiting])
+        XCTAssertEqual(result.map(\.id), ["b", "a", "c"])
+    }
+
+    func testSortedWorkingByMostRecentFirst() {
+        let t0 = Date(timeIntervalSince1970: 0)
+        let t1 = Date(timeIntervalSince1970: 10)
+        let older = AgentSession(id: "old",   agentKind: .claude, state: .working, source: .hook, updatedAt: t0)
+        let newer = AgentSession(id: "newer", agentKind: .cursor, state: .working, source: .hook, updatedAt: t1)
+
+        let result = TickerFormatter.sorted([older, newer])
+        XCTAssertEqual(result.first?.id, "newer", "most recently updated working agent comes first")
+    }
+}

--- a/Tests/AgentPetCoreTests/TickerFormatterTests.swift
+++ b/Tests/AgentPetCoreTests/TickerFormatterTests.swift
@@ -12,6 +12,7 @@ final class TickerFormatterTests: XCTestCase {
         XCTAssertEqual(TickerFormatter.agentLabel(for: .gemini),   "Gemini")
         XCTAssertEqual(TickerFormatter.agentLabel(for: .opencode), "Opencode")
         XCTAssertEqual(TickerFormatter.agentLabel(for: .windsurf), "Windsurf")
+        XCTAssertEqual(TickerFormatter.agentLabel(for: .antigravity), "Antigravity")
     }
 
     func testAgentLabelFallbacks() {

--- a/Tests/AgentPetCoreTests/TranscriptReaderLatestAssistantTextTests.swift
+++ b/Tests/AgentPetCoreTests/TranscriptReaderLatestAssistantTextTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import AgentPetCore
+
+final class TranscriptReaderLatestAssistantTextTests: XCTestCase {
+    private func tempTranscript(_ lines: [String]) throws -> String {
+        let path = NSTemporaryDirectory() + "transcript-\(UUID().uuidString).jsonl"
+        try Data(lines.joined(separator: "\n").utf8).write(to: URL(fileURLWithPath: path))
+        return path
+    }
+
+    private func assistantLine(_ text: String) -> String {
+        let escaped = text.replacingOccurrences(of: "\"", with: "\\\"")
+        return #"{"type":"assistant","message":{"content":[{"type":"text","text":"\#(escaped)"}]}}"#
+    }
+
+    private let userLine = #"{"type":"user","message":{"content":[{"type":"text","text":"thanks"}]}}"#
+
+    func testReturnsLatestAssistantTextVerbatim() throws {
+        let path = try tempTranscript([
+            assistantLine("Working on it now."),
+            userLine,
+            assistantLine("Which approach do you want — A or B?")
+        ])
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        XCTAssertEqual(TranscriptReader.latestAssistantText(at: path),
+                       "Which approach do you want — A or B?")
+    }
+
+    func testSkipsTrailingNonAssistantLines() throws {
+        let path = try tempTranscript([
+            assistantLine("All done — pushed the fix."),
+            userLine
+        ])
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        XCTAssertEqual(TranscriptReader.latestAssistantText(at: path),
+                       "All done — pushed the fix.")
+    }
+
+    func testReturnsNilForUnreadablePath() {
+        XCTAssertNil(TranscriptReader.latestAssistantText(at: "/no/such/file-\(UUID().uuidString).jsonl"))
+    }
+
+    func testReturnsNilWhenNoAssistantLineExists() throws {
+        let path = try tempTranscript([userLine])
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        XCTAssertNil(TranscriptReader.latestAssistantText(at: path))
+    }
+}

--- a/docs/superpowers/plans/2026-06-07-claude-state-detection-fix.md
+++ b/docs/superpowers/plans/2026-06-07-claude-state-detection-fix.md
@@ -1,0 +1,600 @@
+# Claude State-Detection Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop AgentPet from wrongly reporting Claude sessions as "Done" when they're actually waiting on the user (and from flickering done↔working when a subagent finishes mid-task).
+
+**Architecture:** Two `StateMapper` mappings are wrong for Claude: `SubagentStop` shouldn't change session state at all (it fires mid-task, not at session end), and `Stop` always means "done" even when Claude ended its turn by asking the user a question. Fix #1 is a one-line mapping change. Fix #2 needs a small pure `QuestionDetector` unit, a new transcript-reading helper, a race-safe `SessionStore.refineState` correction method, and an `AppDaemon` flow that holds the done/waiting notification until an async transcript check resolves — then fires exactly one notification reflecting the true final state.
+
+**Tech Stack:** Swift 6, XCTest, `@testable import AgentPetCore`
+
+---
+
+## File Structure
+
+- Modify: `Sources/AgentPetCore/StateMapper.swift` — drop the `SubagentStop → .done` mapping
+- Create: `Sources/AgentPetCore/QuestionDetector.swift` — pure text heuristic, no I/O
+- Modify: `Sources/AgentPetCore/TranscriptReader.swift` — add `latestAssistantText(at:)`
+- Modify: `Sources/AgentPetCore/SessionStore.swift` — add `refineState(id:from:to:since:)`
+- Modify: `Sources/App/AppDaemon.swift` — hold-and-fire-once flow for Claude `Stop → .done`
+- Test: `Tests/AgentPetCoreTests/SessionStoreTests.swift` — `StateMapperTests` + `SessionStoreTests` updates
+- Test: `Tests/AgentPetCoreTests/QuestionDetectorTests.swift` — new
+- Test: `Tests/AgentPetCoreTests/TranscriptReaderLatestAssistantTextTests.swift` — new
+
+---
+
+## Task 1: Stop mapping `SubagentStop` to `.done`
+
+**Files:**
+- Modify: `Sources/AgentPetCore/StateMapper.swift:30`
+- Test: `Tests/AgentPetCoreTests/SessionStoreTests.swift:12` (existing `testClaudeEventMapping`)
+
+- [ ] **Step 1: Update the existing test to expect `nil`**
+
+In `Tests/AgentPetCoreTests/SessionStoreTests.swift`, find this line inside `testClaudeEventMapping` (around line 12):
+
+```swift
+        XCTAssertEqual(StateMapper.state(for: .claude, eventName: "SubagentStop"), .done)
+```
+
+Replace it with:
+
+```swift
+        XCTAssertNil(StateMapper.state(for: .claude, eventName: "SubagentStop"),
+                     "a subagent finishing mid-task must not change the main session's state")
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `swift test --filter StateMapperTests/testClaudeEventMapping -v`
+Expected: FAIL — `XCTAssertNil failed: "done"` (current mapping still returns `.done`)
+
+- [ ] **Step 3: Fix the mapping**
+
+In `Sources/AgentPetCore/StateMapper.swift`, the Claude case currently reads (around line 25-32):
+
+```swift
+        case .claude:
+            switch eventName {
+            case "SessionStart": return .registered
+            case "UserPromptSubmit", "PreToolUse", "PostToolUse": return .working
+            case "Notification": return .waiting
+            case "Stop", "SubagentStop": return .done
+            default: return nil
+            }
+```
+
+Change it to:
+
+```swift
+        case .claude:
+            switch eventName {
+            case "SessionStart": return .registered
+            case "UserPromptSubmit", "PreToolUse", "PostToolUse": return .working
+            case "Notification": return .waiting
+            case "Stop": return .done
+            // SubagentStop fires when a Task() subagent finishes mid-session —
+            // not when the main session is done. Ignoring it (nil = "no state
+            // change") avoids a false done→working flicker.
+            case "SubagentStop": return nil
+            default: return nil
+            }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `swift test --filter StateMapperTests/testClaudeEventMapping -v`
+Expected: PASS
+
+- [ ] **Step 5: Check the hook-coverage test still passes**
+
+`testHookSpecsCoverInstallEvents` (in the same file) asserts every registered hook event maps to a non-nil state unless it's a session-end event. `SubagentStop` is registered for Claude (`AgentHooks.swift:35`) and is *not* a session-end event, so this assertion would now fail for it. Run:
+
+Run: `swift test --filter StateMapperTests/testHookSpecsCoverInstallEvents -v`
+Expected: FAIL — `XCTAssertNotNil failed - claude SubagentStop`
+
+This is expected: the test's premise ("every registered event must map to a state") is no longer true now that we're intentionally ignoring one. Update the test to allow a documented exception. Find this in the same file:
+
+```swift
+    func testHookSpecsCoverInstallEvents() {
+        // Every event we register must either map to a state or end the session.
+        for kind in [AgentKind.claude, .codex, .gemini] {
+            let spec = AgentHooks.spec(for: kind)!
+            for event in spec.events where !StateMapper.isSessionEnd(for: kind, eventName: event) {
+                XCTAssertNotNil(StateMapper.state(for: kind, eventName: event), "\(kind) \(event)")
+            }
+        }
+    }
+```
+
+Replace it with:
+
+```swift
+    func testHookSpecsCoverInstallEvents() {
+        // Every event we register must either map to a state, end the session,
+        // or be an intentionally-ignored event (documented here).
+        let intentionallyIgnored: [AgentKind: Set<String>] = [
+            .claude: ["SubagentStop"]
+        ]
+        for kind in [AgentKind.claude, .codex, .gemini] {
+            let spec = AgentHooks.spec(for: kind)!
+            let ignored = intentionallyIgnored[kind] ?? []
+            for event in spec.events
+            where !StateMapper.isSessionEnd(for: kind, eventName: event) && !ignored.contains(event) {
+                XCTAssertNotNil(StateMapper.state(for: kind, eventName: event), "\(kind) \(event)")
+            }
+        }
+    }
+```
+
+- [ ] **Step 6: Run the full StateMapper test suite**
+
+Run: `swift test --filter StateMapperTests -v`
+Expected: PASS — all tests green
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/AgentPetCore/StateMapper.swift Tests/AgentPetCoreTests/SessionStoreTests.swift
+git commit -m "fix(core): ignore SubagentStop instead of marking the session done
+
+A Task() subagent finishing mid-session isn't the main session finishing —
+the main loop resumes right after, producing a false done→working flicker.
+Map it to nil (no state change) like other irrelevant events."
+```
+
+---
+
+## Task 2: `QuestionDetector` — pure question-phrase heuristic
+
+**Files:**
+- Create: `Sources/AgentPetCore/QuestionDetector.swift`
+- Test: `Tests/AgentPetCoreTests/QuestionDetectorTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AgentPetCoreTests/QuestionDetectorTests.swift`:
+
+```swift
+import XCTest
+@testable import AgentPetCore
+
+final class QuestionDetectorTests: XCTestCase {
+    func testEndsWithQuestionMark() {
+        XCTAssertTrue(QuestionDetector.looksLikeQuestion("Which approach do you prefer, A or B?"))
+    }
+
+    func testTrailingWhitespaceAfterQuestionMarkStillDetected() {
+        XCTAssertTrue(QuestionDetector.looksLikeQuestion("Want me to push this too?  \n"))
+    }
+
+    func testRequestForDirectionPhraseWithoutQuestionMark() {
+        XCTAssertTrue(QuestionDetector.looksLikeQuestion(
+            "I've made the change. Let me know if you'd like any tweaks."))
+        XCTAssertTrue(QuestionDetector.looksLikeQuestion(
+            "Should I go ahead and run the migration now"))
+    }
+
+    func testPlainCompletionStatementIsNotAQuestion() {
+        XCTAssertFalse(QuestionDetector.looksLikeQuestion(
+            "Done — fixed the login bug and added a regression test."))
+    }
+
+    func testEmptyAndWhitespaceOnlyAreNotQuestions() {
+        XCTAssertFalse(QuestionDetector.looksLikeQuestion(""))
+        XCTAssertFalse(QuestionDetector.looksLikeQuestion("   \n  "))
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --filter QuestionDetectorTests -v`
+Expected: FAIL — `cannot find 'QuestionDetector' in scope`
+
+- [ ] **Step 3: Implement `QuestionDetector`**
+
+Create `Sources/AgentPetCore/QuestionDetector.swift`:
+
+```swift
+import Foundation
+
+/// Detects whether a piece of assistant text reads like Claude ended its turn
+/// by asking the user something — as opposed to simply reporting completion.
+///
+/// Pure string logic: no I/O, no actor isolation. Used to correct a session's
+/// state from `.done` to `.waiting` when Claude's `Stop` hook fires after a
+/// turn that actually ended in a question (Claude Code sends no separate event
+/// for "I asked the user something and am waiting for a reply").
+public enum QuestionDetector {
+    private static let directionPhrases = [
+        "let me know",
+        "should i",
+        "which would you",
+        "do you want",
+        "want me to",
+        "shall i",
+        "would you like"
+    ]
+
+    /// True if `text` looks like a request for the user's direction: it ends
+    /// with a question mark, or contains a recognizable "asking what to do
+    /// next" phrase.
+    public static func looksLikeQuestion(_ text: String) -> Bool {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        if trimmed.hasSuffix("?") { return true }
+        let lowered = trimmed.lowercased()
+        return directionPhrases.contains { lowered.contains($0) }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --filter QuestionDetectorTests -v`
+Expected: PASS — all 5 tests green
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AgentPetCore/QuestionDetector.swift Tests/AgentPetCoreTests/QuestionDetectorTests.swift
+git commit -m "feat(core): add QuestionDetector heuristic for turn-ending questions
+
+Pure text check used to tell 'Claude is truly done' apart from 'Claude
+ended its turn by asking the user something' — Stop fires identically
+for both, so AgentPet needs its own signal."
+```
+
+---
+
+## Task 3: `TranscriptReader.latestAssistantText` — raw last-assistant-message text
+
+**Files:**
+- Modify: `Sources/AgentPetCore/TranscriptReader.swift`
+- Test: `Tests/AgentPetCoreTests/TranscriptReaderLatestAssistantTextTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `Tests/AgentPetCoreTests/TranscriptReaderLatestAssistantTextTests.swift`:
+
+```swift
+import XCTest
+@testable import AgentPetCore
+
+final class TranscriptReaderLatestAssistantTextTests: XCTestCase {
+    private func tempTranscript(_ lines: [String]) throws -> String {
+        let path = NSTemporaryDirectory() + "transcript-\(UUID().uuidString).jsonl"
+        try Data(lines.joined(separator: "\n").utf8).write(to: URL(fileURLWithPath: path))
+        return path
+    }
+
+    private func assistantLine(_ text: String) -> String {
+        let escaped = text.replacingOccurrences(of: "\"", with: "\\\"")
+        return #"{"type":"assistant","message":{"content":[{"type":"text","text":"\#(escaped)"}]}}"#
+    }
+
+    private let userLine = #"{"type":"user","message":{"content":[{"type":"text","text":"thanks"}]}}"#
+
+    func testReturnsLatestAssistantTextVerbatim() throws {
+        let path = try tempTranscript([
+            assistantLine("Working on it now."),
+            userLine,
+            assistantLine("Which approach do you want — A or B?")
+        ])
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        XCTAssertEqual(TranscriptReader.latestAssistantText(at: path),
+                       "Which approach do you want — A or B?")
+    }
+
+    func testSkipsTrailingNonAssistantLines() throws {
+        let path = try tempTranscript([
+            assistantLine("All done — pushed the fix."),
+            userLine
+        ])
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        XCTAssertEqual(TranscriptReader.latestAssistantText(at: path),
+                       "All done — pushed the fix.")
+    }
+
+    func testReturnsNilForUnreadablePath() {
+        XCTAssertNil(TranscriptReader.latestAssistantText(at: "/no/such/file-\(UUID().uuidString).jsonl"))
+    }
+
+    func testReturnsNilWhenNoAssistantLineExists() throws {
+        let path = try tempTranscript([userLine])
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        XCTAssertNil(TranscriptReader.latestAssistantText(at: path))
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --filter TranscriptReaderLatestAssistantTextTests -v`
+Expected: FAIL — `value of type 'TranscriptReader.Type' has no member 'latestAssistantText'`
+
+- [ ] **Step 3: Implement `latestAssistantText`**
+
+In `Sources/AgentPetCore/TranscriptReader.swift`, add this new public function. Place it directly after `latestAssistantRecap` (after line 37, before the `clearCache` method):
+
+```swift
+    /// Returns the raw, trimmed text of the most recent Claude assistant
+    /// message in the transcript (capped at 400 characters), or `nil` if none
+    /// is found. Unlike `latestAssistantRecap`, this returns ordinary
+    /// turn-ending text too — it's used to check whether Claude ended its
+    /// turn by asking the user a question, not to extract a named recap.
+    public static func latestAssistantText(at path: String) -> String? {
+        guard let handle = FileHandle(forReadingAtPath: path) else { return nil }
+        defer { try? handle.close() }
+
+        let fileSize = (try? handle.seekToEnd()) ?? 0
+        let maxBytes: UInt64 = 131_072
+        try? handle.seek(toOffset: fileSize > maxBytes ? fileSize - maxBytes : 0)
+        let raw = handle.readDataToEndOfFile()
+        guard let text = String(data: raw, encoding: .utf8) else { return nil }
+
+        for line in text.components(separatedBy: "\n").reversed() {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty,
+                  let lineData = trimmed.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                  json["type"] as? String == "assistant",
+                  let assistantText = extractAssistantText(from: json)
+            else { continue }
+            return String(assistantText.trimmingCharacters(in: .whitespacesAndNewlines).prefix(400))
+        }
+
+        return nil
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --filter TranscriptReaderLatestAssistantTextTests -v`
+Expected: PASS — all 4 tests green
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AgentPetCore/TranscriptReader.swift Tests/AgentPetCoreTests/TranscriptReaderLatestAssistantTextTests.swift
+git commit -m "feat(core): add TranscriptReader.latestAssistantText
+
+Raw last-assistant-message text (no recap-marker filtering), used by the
+done/waiting question heuristic to inspect how Claude ended its turn."
+```
+
+---
+
+## Task 4: `SessionStore.refineState` — race-safe done→waiting correction
+
+**Files:**
+- Modify: `Sources/AgentPetCore/SessionStore.swift`
+- Test: `Tests/AgentPetCoreTests/SessionStoreTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `Tests/AgentPetCoreTests/SessionStoreTests.swift`, add these three tests inside `final class SessionStoreTests` (e.g. directly after `testApplyIgnoresUnmappedEvent`, around line 80):
+
+```swift
+    func testRefineStateAppliesWhenStateAndSinceStillMatch() {
+        let store = SessionStore()
+        let applied = store.apply(event("Stop"), now: t0)
+        XCTAssertEqual(applied?.state, .done)
+
+        store.refineState(id: "s1", from: .done, to: .waiting, since: applied!.stateSince)
+
+        let refined = store.session(id: "s1")
+        XCTAssertEqual(refined?.state, .waiting)
+        XCTAssertEqual(refined?.stateSince, applied!.stateSince,
+                       "correction preserves the original transition time")
+    }
+
+    func testRefineStateNoOpsWhenANewerEventAlreadyChangedState() {
+        let store = SessionStore()
+        let applied = store.apply(event("Stop"), now: t0)
+        store.apply(event("UserPromptSubmit"), now: t0.addingTimeInterval(2))   // user replied -> working
+
+        store.refineState(id: "s1", from: .done, to: .waiting, since: applied!.stateSince)
+
+        XCTAssertEqual(store.session(id: "s1")?.state, .working,
+                       "a newer transition must never be clobbered by a stale correction")
+    }
+
+    func testRefineStateNoOpsWhenSinceNoLongerMatches() {
+        let store = SessionStore()
+        let applied = store.apply(event("Stop"), now: t0)
+        let staleSince = applied!.stateSince.addingTimeInterval(-10)
+
+        store.refineState(id: "s1", from: .done, to: .waiting, since: staleSince)
+
+        XCTAssertEqual(store.session(id: "s1")?.state, .done,
+                       "a `since` mismatch means this correction targets a transition that's gone")
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `swift test --filter SessionStoreTests/testRefineState -v`
+Expected: FAIL — `value of type 'SessionStore' has no member 'refineState'`
+
+- [ ] **Step 3: Implement `refineState`**
+
+In `Sources/AgentPetCore/SessionStore.swift`, add this method directly after `updateTitle` (after line 48, before `apply`):
+
+```swift
+    /// Corrects a session's state after the fact — used when an async check
+    /// (e.g. reading the transcript to see how Claude ended its turn)
+    /// determines the state we set synchronously was wrong.
+    ///
+    /// Only applies when the session is *still* in `expected` state from the
+    /// *same* transition (`since` matches `stateSince`): if a newer event has
+    /// already moved the session on, this is a no-op — the correction targets
+    /// a transition that no longer exists, and must never clobber fresher
+    /// state. `stateSince` is preserved (this corrects the existing
+    /// transition; it isn't a new one).
+    public func refineState(id: String, from expected: AgentState, to refined: AgentState, since: Date) {
+        guard var session = byID[id], session.state == expected, session.stateSince == since else { return }
+        session.state = refined
+        byID[id] = session
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `swift test --filter SessionStoreTests/testRefineState -v`
+Expected: PASS — all 3 tests green
+
+- [ ] **Step 5: Run the full SessionStore suite to confirm no regressions**
+
+Run: `swift test --filter SessionStoreTests -v`
+Expected: PASS — all tests green
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/AgentPetCore/SessionStore.swift Tests/AgentPetCoreTests/SessionStoreTests.swift
+git commit -m "feat(core): add SessionStore.refineState for race-safe state correction
+
+Lets an async check (transcript read) correct a synchronously-applied
+state without ever clobbering a newer transition — guarded by both the
+expected state and its stateSince timestamp."
+```
+
+---
+
+## Task 5: `AppDaemon` — hold-and-fire-once for Claude `Stop → .done`
+
+**Files:**
+- Modify: `Sources/App/AppDaemon.swift:54-92`
+
+This task wires the previous three units together. There's no existing test
+harness for `AppDaemon` (it's a `@MainActor` singleton coupled to sockets and
+`NotificationManager`), so this task is verified by building and by the
+existing full test suite passing — consistent with how `resolveTitle` (the
+pattern this mirrors) is untested today.
+
+- [ ] **Step 1: Replace `ingest` and add the correction helper**
+
+In `Sources/App/AppDaemon.swift`, the current `ingest` (lines 54-61) reads:
+
+```swift
+    private func ingest(_ event: AgentEvent) {
+        let before = store.session(id: event.sessionId)?.state
+        if let updated = store.apply(event, now: Date()) {
+            notifyIfNeeded(before: before, session: updated)
+            resolveTitle(for: event)
+        }
+        refresh()
+    }
+```
+
+Replace it with:
+
+```swift
+    private func ingest(_ event: AgentEvent) {
+        let before = store.session(id: event.sessionId)?.state
+        guard let updated = store.apply(event, now: Date()) else {
+            refresh()
+            return
+        }
+        resolveTitle(for: event)
+
+        // Claude's Stop hook fires identically whether the agent is truly
+        // done or just ended its turn by asking the user a question — hold
+        // the notification until an async transcript check resolves, so we
+        // fire exactly one notification reflecting the true final state.
+        if event.agentKind == .claude, event.eventName == "Stop", updated.state == .done {
+            refineDoneIfQuestion(event: event, before: before, session: updated)
+        } else {
+            notifyIfNeeded(before: before, session: updated)
+        }
+        refresh()
+    }
+
+    /// Reads the transcript off-thread to check whether Claude ended its turn
+    /// by asking the user something; if so, corrects `.done` to `.waiting`.
+    /// Either way, fires the (single, final-state) notification afterwards.
+    private func refineDoneIfQuestion(event: AgentEvent, before: AgentState?, session: AgentSession) {
+        let sessionId = event.sessionId
+        let stateSince = session.stateSince
+        let path: String? = event.transcriptPath
+            ?? event.project.map { TranscriptReader.inferredPath(sessionId: sessionId, cwd: $0) }
+        guard let path else {
+            notifyIfNeeded(before: before, session: session)
+            return
+        }
+        Task.detached(priority: .utility) { [weak self] in
+            let isQuestion = TranscriptReader.latestAssistantText(at: path)
+                .map(QuestionDetector.looksLikeQuestion) ?? false
+            await MainActor.run { [weak self] in
+                guard let self else { return }
+                if isQuestion {
+                    self.store.refineState(id: sessionId, from: .done, to: .waiting, since: stateSince)
+                }
+                guard let final = self.store.session(id: sessionId) else { return }
+                self.notifyIfNeeded(before: before, session: final)
+                self.refresh()
+            }
+        }
+    }
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `swift build`
+Expected: `Build complete!` with no errors or warnings about the new code
+
+- [ ] **Step 3: Run the full test suite to confirm no regressions**
+
+Run: `swift test 2>&1 | tail -30`
+Expected: all suites pass (`Executed N tests, with 0 failures`)
+
+- [ ] **Step 4: Manual smoke check (optional but recommended)**
+
+Launch the app (`swift run agentpet` or via Xcode), start a Claude Code
+session in a watched project, and:
+- Ask Claude to do something simple, then have it end by asking you a
+  clarifying question (e.g. "implement X, but first ask me which of two
+  approaches I'd prefer"). Confirm the bubble shows **Waiting** (not Done)
+  and you get exactly one "needs input" notification — not a "finished"
+  notification followed by a correction.
+- Ask Claude to do something that finishes cleanly with no question.
+  Confirm it still shows **Done** promptly with one "finished" notification.
+- Trigger a `Task()` subagent (e.g. "use a subagent to look up X, then
+  continue working"). Confirm the bubble does *not* flash "Done" when the
+  subagent finishes — it should stay "Working".
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/App/AppDaemon.swift
+git commit -m "fix(app): correct done->waiting for Claude turns that end in a question
+
+Stop fires identically for 'truly done' and 'ended turn by asking the
+user something' — neither AgentPet nor the hook payload can tell them
+apart without reading the transcript. Hold the notification for Claude
+Stop->done specifically, check asynchronously, correct if needed, and
+fire exactly one notification reflecting the true final state."
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Fix 1 (Task 1), `QuestionDetector` (Task 2),
+  `latestAssistantText` (Task 3), `refineState` (Task 4), hold-and-fire-once
+  `AppDaemon` flow (Task 5) — all five spec sections have a task.
+- **No setting added** — matches "Out of scope" in the spec (correctness
+  fix, not a preference).
+- **Non-Claude agents untouched** — `refineDoneIfQuestion` is gated on
+  `event.agentKind == .claude`, so Codex/Gemini/etc. keep firing
+  `notifyIfNeeded` immediately as before.
+- **Type/signature consistency checked:** `refineState(id:from:to:since:)`
+  signature matches between Task 4's implementation and Task 5's call site;
+  `QuestionDetector.looksLikeQuestion(_:)` and
+  `TranscriptReader.latestAssistantText(at:)` signatures match between their
+  Task 2/3 implementations and the Task 5 call site.

--- a/docs/superpowers/specs/2026-06-07-claude-state-detection-fix-design.md
+++ b/docs/superpowers/specs/2026-06-07-claude-state-detection-fix-design.md
@@ -1,0 +1,119 @@
+# Fix Claude state-detection: SubagentStop + done/waiting question heuristic
+
+## Problem
+
+`StateMapper` (Sources/AgentPetCore/StateMapper.swift) maps Claude Code hook
+events to `AgentState`, which drives notifications, sounds, pet mood/animation,
+and the multi-agent bubble — for *all* users, regardless of which bubble UI
+they have enabled. Two mappings are wrong:
+
+1. **`SubagentStop → .done`** — fires when a `Task()` subagent finishes
+   mid-session, not when the main session is done. The main loop resumes
+   (`PreToolUse`/`PostToolUse`) right after, so this produces a false
+   "Done" flash that flips back to "Working" moments later.
+
+2. **`Stop → .done` always** — Claude Code fires `Stop` at the end of *every*
+   assistant turn, including turns where Claude ends by asking the user a
+   plain-text clarifying question ("Which approach do you want — A or B?").
+   No `Notification`/permission event accompanies that. AgentPet has no
+   signal to distinguish "truly done" from "done talking, waiting on your
+   reply," so it shows **Done** (and fires a "finished" notification/sound)
+   when Claude is actually **waiting for the user**.
+
+This fix applies to the underlying state — and therefore to notifications,
+sounds, and pet mood for everyone — not just to the multi-agent bubble
+display.
+
+## Fix 1 — Drop `SubagentStop` mapping
+
+`StateMapper.state(for: .claude, eventName: "SubagentStop")` returns `nil`
+instead of `.done`. A `nil` result means "ignore this event, don't change
+state" (existing behavior for unknown events). One-line change.
+
+## Fix 2 — Detect "ended by asking a question" and correct done → waiting
+
+Claude Code's `Stop` hook payload carries no reply text — only session id and
+transcript path. So detection requires reading the transcript file
+asynchronously (the same pattern `resolveTitle` already uses for title
+resolution) and correcting the state after the fact if needed.
+
+### New unit: `QuestionDetector`
+
+`Sources/AgentPetCore/QuestionDetector.swift`:
+
+```swift
+public enum QuestionDetector {
+    /// True if `text` reads like Claude ended its turn by asking the user
+    /// something (a question mark, or a request-for-direction phrase).
+    public static func looksLikeQuestion(_ text: String) -> Bool
+}
+```
+
+Pure string logic — trims/lowercases, returns true if the text ends with `?`,
+or contains phrases such as "let me know", "should i", "which would you",
+"do you want", "want me to", "shall i", "would you like". No I/O, no actor
+isolation — independently unit-testable.
+
+### New `TranscriptReader.latestAssistantText(at:)`
+
+Mirrors the tail-scan already in `readLatestAssistantRecap` (scan lines from
+the end of the file, find the last `"assistant"` event, extract its text via
+the existing `extractAssistantText`) but returns the **raw trimmed text**
+without the `cleanRecap` "recap:"/"summary:" marker filter — that filter is
+specific to the recap feature and would return `nil` for ordinary turn-ending
+messages, which is exactly the case we need to inspect here. Capped at a few
+hundred characters — plenty to evaluate the heuristic.
+
+### New `SessionStore.refineState(id:from:to:since:)`
+
+```swift
+public func refineState(id: String, from expected: AgentState, to refined: AgentState, since: Date) {
+    guard var s = byID[id], s.state == expected, s.stateSince == since else { return }
+    s.state = refined
+    byID[id] = s
+}
+```
+
+The `expected`/`since` guards make this race-safe: if a newer event (e.g. the
+user already replied, triggering `UserPromptSubmit → .working`) landed before
+the async check resolves, the correction is silently skipped — it never
+clobbers fresher state. `stateSince` is preserved (this is a correction of the
+existing transition, not a new one), so elapsed-time display stays accurate.
+
+### `AppDaemon` flow — hold-and-fire-once notification
+
+In `ingest`, when the event is Claude's `Stop` and the resulting state is
+`.done`:
+
+- Apply the state immediately as today — the UI shows "Done" right away (fast
+  feedback for the common, correct case).
+- Skip the immediate `notifyIfNeeded` call for *this* transition only.
+- Launch `Task.detached(priority: .utility)`: read `latestAssistantText`,
+  run `QuestionDetector.looksLikeQuestion`. If it matches, call
+  `store.refineState(id:from: .done, to: .waiting, since:)`. Either way, then
+  call `notifyIfNeeded(before:, session:)` on the main actor with the
+  *final* (possibly corrected) session — exactly one notification/sound is
+  fired, reflecting the true final state.
+- All other transitions (including non-Claude agents, and Claude transitions
+  to `.working`/`.waiting`/`.registered`) keep firing `notifyIfNeeded`
+  immediately — unchanged.
+
+## Testing
+
+- `QuestionDetector` — pure unit tests covering question marks, phrase
+  patterns, plain statements (no false positive), and edge cases (empty
+  string, trailing whitespace/punctuation).
+- `SessionStore.refineState` — unit tests: applies when state/since match,
+  no-ops when state has moved on, no-ops when `stateSince` has changed
+  (i.e. a newer transition superseded it).
+- `StateMapper` — test that `SubagentStop` now maps to `nil` for Claude.
+- `TranscriptReader.latestAssistantText` — test against fixture transcripts
+  (question-ending vs statement-ending last assistant message).
+
+## Out of scope
+
+- No user-facing setting to disable this — it's a correctness fix, not a
+  style preference (per discussion).
+- No changes to non-Claude agent kinds (Codex, Gemini, etc.) — they don't
+  send `Stop`/`SubagentStop` with the same semantics, and don't have a
+  transcript reader.


### PR DESCRIPTION
### Summary

Agent ticker chat bubble — replaces the static pet chat with a live, structured view of running coding-agent sessions (Claude/Codex/Gemini/etc), shown both as a speech bubble above the pet and as a panel hanging from the menu bar.

### Core feature

- TickerFormag/grouping ofagent sessions into display lines (waiting sessions surface firstorking ones)
- Agent bubble UI — speech bubble listing one row per  (agent kind, d stateindicators (working/waiting/done), rendered both as a  pet-chat bubb panel (tailup)                                                    - Bubble grouaring an agentkind collapse into a single row with a count; multiple groups rotateth swipenavigation; a compact layout op- Spring-animfades andresizes with spring physics as changes, inst
- Display settings (BubbleSettiuser-configurch fields eachrow shows), icon style, color tand a live pr
- Configurable activity messageWizard, Exploescribing whatan agent is doing, with rotatinand extension
- State messages — done-state s(extracted fre showsmotivational "idle boost" linesrunning
                               This PR's add
                               - Theme consible washard-coded to white background BubbleSettingcity, and font size exactly like the menu-bar - Mode gatinge and thedefault PetChat pool no longer enabling multandompersonality-chat lines during wown the messadown agentstate so the agent bubble can nidle/celebratd either way;toggling mid-session rebuilds capplyBubbleMo
- Claude state-detection fix — whether Claudd to ask theuser a question, causing false notificationsop is ignored(was wrongly marking sessions ddone is held,st thetranscript (QuestionDetector + TranscriptRea corrected towaiting if Claude ended on a question — race-safe via SessionStore.timestampguards, firing exactly one final notification
