### PR TITLE
feat(app): add reactive pet bubbles based on global metrics

### DIFF
--- a/Localizations/en.lproj/Localizable.strings
+++ b/Localizations/en.lproj/Localizable.strings
@@ -370,6 +370,73 @@
 "Opens buymeacoffee.com in your browser." = "Opens buymeacoffee.com in your browser.";
 "Quét bằng app ngân hàng bất kỳ (VPBank · NGUYEN THANH DAT)" = "Scan with any banking app (VPBank · NGUYEN THANH DAT)";
 
+/* Reactive bubbles — settings */
+"Pet reactive bubbles" = "Pet reactive bubbles";
+"Pet reacts to rate limits, token usage, hunger, and streaks." = "Pet reacts to rate limits, token usage, hunger, and streaks.";
+
+/* Reactive bubbles — rate limit */
+"Usage is climbing~" = "Usage is climbing~";
+"Take it easy, no rush" = "Take it easy, no rush";
+"Keep an eye on quota" = "Keep an eye on quota";
+"Rate limit running low…" = "Rate limit running low…";
+"Use sparingly!" = "Use sparingly!";
+"Quota getting thin" = "Quota getting thin";
+"Almost out of quota 😰" = "Almost out of quota 😰";
+"Maybe take a break…" = "Maybe take a break…";
+"Quota nearly spent" = "Quota nearly spent";
+
+/* Reactive bubbles — daily tokens */
+"Burned quite a few tokens today~" = "Burned quite a few tokens today~";
+"Eaten a lot of tokens" = "Eaten a lot of tokens";
+"Token usage rising" = "Token usage rising";
+"Big appetite mode!" = "Big appetite mode!";
+"Great appetite today~" = "Great appetite today~";
+"Tokens going fast" = "Tokens going fast";
+"Token usage off the charts today 🔥" = "Token usage off the charts today 🔥";
+"Token burn is extreme!" = "Token burn is extreme!";
+"Heavy burn today" = "Heavy burn today";
+
+/* Reactive bubbles — session count */
+"5 agents running at once~" = "5 agents running at once~";
+"Lots of agents at work" = "Lots of agents at work";
+"Parallelism is up" = "Parallelism is up";
+"Command center mode 😳" = "Command center mode 😳";
+"So many sessions!" = "So many sessions!";
+"Full throttle" = "Full throttle";
+
+/* Reactive bubbles — hunger */
+"A little hungry…" = "A little hungry…";
+"Hmm… want food" = "Hmm… want food";
+"Tummy rumbling" = "Tummy rumbling";
+"Haven't been fed in a while 😢" = "Haven't been fed in a while 😢";
+"Hungry…" = "Hungry…";
+"Want food…" = "Want food…";
+"Where did you go… 😭" = "Where did you go… 😭";
+"About to faint from hunger" = "About to faint from hunger";
+"So hungry" = "So hungry";
+
+/* Reactive bubbles — streak */
+"Days in a row! Keep going" = "Days in a row! Keep going";
+"Going strong~" = "Going strong~";
+"Keeping it up" = "Keeping it up";
+"A whole week straight!" = "A whole week straight!";
+"Such persistence~" = "Such persistence~";
+"So consistent" = "So consistent";
+"Legendary streak!" = "Legendary streak!";
+"Incredible!" = "Incredible!";
+"Unstoppable" = "Unstoppable";
+
+/* Reactive bubbles — daily meals */
+"Lots of sessions today~" = "Lots of sessions today~";
+"Good productivity" = "Good productivity";
+"Got quite a bit done" = "Got quite a bit done";
+"Fifty sessions! Efficiency beast" = "Fifty sessions! Efficiency beast";
+"50+!" = "50+!";
+"Super productive" = "Super productive";
+"Over 100! Not sleeping today?" = "Over 100! Not sleeping today?";
+"100+ sessions!" = "100+ sessions!";
+"Superhuman" = "Superhuman";
+
 /* HUD footer */
 "Settings" = "Settings";
 "Updates" = "Updates";

--- a/Localizations/vi.lproj/Localizable.strings
+++ b/Localizations/vi.lproj/Localizable.strings
@@ -371,6 +371,73 @@
 "Opens buymeacoffee.com in your browser." = "Mở buymeacoffee.com trên trình duyệt.";
 "Quét bằng app ngân hàng bất kỳ (VPBank · NGUYEN THANH DAT)" = "Quét bằng app ngân hàng bất kỳ (VPBank · NGUYEN THANH DAT)";
 
+/* Reactive bubbles — settings */
+"Pet reactive bubbles" = "Bong bóng phản ứng";
+"Pet reacts to rate limits, token usage, hunger, and streaks." = "Pet phản ứng với giới hạn tốc độ, lượng token, độ đói và chuỗi ngày.";
+
+/* Reactive bubbles — rate limit */
+"Usage is climbing~" = "Lượng dùng đang tăng~";
+"Take it easy, no rush" = "Từ từ thôi, không vội";
+"Keep an eye on quota" = "Để ý quota nhé";
+"Rate limit running low…" = "Rate limit sắp hết…";
+"Use sparingly!" = "Dùng tiết kiệm nhé!";
+"Quota getting thin" = "Quota không còn nhiều";
+"Almost out of quota 😰" = "Gần hết quota rồi 😰";
+"Maybe take a break…" = "Nghỉ một chút đi…";
+"Quota nearly spent" = "Quota gần cạn";
+
+/* Reactive bubbles — daily tokens */
+"Burned quite a few tokens today~" = "Hôm nay đốt kha khá token~";
+"Eaten a lot of tokens" = "Ăn nhiều token rồi";
+"Token usage rising" = "Lượng token đang tăng";
+"Big appetite mode!" = "Chế độ ăn khỏe!";
+"Great appetite today~" = "Hôm nay ăn khỏe quá~";
+"Tokens going fast" = "Token hết nhanh lắm";
+"Token usage off the charts today 🔥" = "Lượng token hôm nay bùng nổ 🔥";
+"Token burn is extreme!" = "Đốt token cực kỳ nhiều!";
+"Heavy burn today" = "Hôm nay đốt dữ";
+
+/* Reactive bubbles — session count */
+"5 agents running at once~" = "5 agent chạy cùng lúc~";
+"Lots of agents at work" = "Nhiều agent đang làm việc";
+"Parallelism is up" = "Chạy song song khá nhiều";
+"Command center mode 😳" = "Chế độ trung tâm chỉ huy 😳";
+"So many sessions!" = "Nhiều session quá!";
+"Full throttle" = "Chạy hết công suất";
+
+/* Reactive bubbles — hunger */
+"A little hungry…" = "Hơi đói…";
+"Hmm… want food" = "Hmm… muốn ăn";
+"Tummy rumbling" = "Bụng đang kêu";
+"Haven't been fed in a while 😢" = "Lâu rồi chưa được cho ăn 😢";
+"Hungry…" = "Đói…";
+"Want food…" = "Muốn ăn…";
+"Where did you go… 😭" = "Bạn đi đâu rồi… 😭";
+"About to faint from hunger" = "Sắp ngất vì đói";
+"So hungry" = "Đói quá";
+
+/* Reactive bubbles — streak */
+"Days in a row! Keep going" = "Mấy ngày liên tục! Cố lên";
+"Going strong~" = "Đang rất tốt~";
+"Keeping it up" = "Giữ vững nhé";
+"A whole week straight!" = "Cả tuần liên tục!";
+"Such persistence~" = "Kiên trì quá~";
+"So consistent" = "Ổn định ghê";
+"Legendary streak!" = "Chuỗi ngày huyền thoại!";
+"Incredible!" = "Quá đỉnh!";
+"Unstoppable" = "Không ai cản nổi";
+
+/* Reactive bubbles — daily meals */
+"Lots of sessions today~" = "Hôm nay xong nhiều session~";
+"Good productivity" = "Năng suất tốt";
+"Got quite a bit done" = "Làm được kha khá";
+"Fifty sessions! Efficiency beast" = "Năm mươi session! Quái vật hiệu suất";
+"50+!" = "50+!";
+"Super productive" = "Siêu năng suất";
+"Over 100! Not sleeping today?" = "Hơn 100! Hôm nay không ngủ à?";
+"100+ sessions!" = "100+ session!";
+"Superhuman" = "Siêu nhân";
+
 /* HUD footer */
 "Settings" = "Cài đặt";
 "Updates" = "Cập nhật";

--- a/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/Localizations/zh-Hans.lproj/Localizable.strings
@@ -370,6 +370,73 @@
 "Opens buymeacoffee.com in your browser." = "在浏览器打开 buymeacoffee.com。";
 "Quét bằng app ngân hàng bất kỳ (VPBank · NGUYEN THANH DAT)" = "用任意银行 App 扫码（VPBank · NGUYEN THANH DAT）";
 
+/* Reactive bubbles — settings */
+"Pet reactive bubbles" = "宠物反应气泡";
+"Pet reacts to rate limits, token usage, hunger, and streaks." = "宠物会对速率限制、token 用量、饥饿度和连续天数作出反应。";
+
+/* Reactive bubbles — rate limit */
+"Usage is climbing~" = "用量开始升了～";
+"Take it easy, no rush" = "慢慢来，不急";
+"Keep an eye on quota" = "留意一下 quota";
+"Rate limit running low…" = "Rate limit 快见底了…";
+"Use sparingly!" = "要省着用了！";
+"Quota getting thin" = "Quota 不多了";
+"Almost out of quota 😰" = "差不多没 quota 了 😰";
+"Maybe take a break…" = "停一停吧…";
+"Quota nearly spent" = "Quota 几乎用完";
+
+/* Reactive bubbles — daily tokens */
+"Burned quite a few tokens today~" = "今天烧了不少 token～";
+"Eaten a lot of tokens" = "吃了好多 token 了";
+"Token usage rising" = "Token 消耗上升中";
+"Big appetite mode!" = "大胃王模式！";
+"Great appetite today~" = "今天胃口真好～";
+"Tokens going fast" = "Token 消耗得好快";
+"Token usage off the charts today 🔥" = "今天 token 用量爆炸 🔥";
+"Token burn is extreme!" = "Token 消耗超高！";
+"Heavy burn today" = "今天 burn 好猛";
+
+/* Reactive bubbles — session count */
+"5 agents running at once~" = "5 个 agent 同时在跑～";
+"Lots of agents at work" = "好多 agent 在干活";
+"Parallelism is up" = "并行度不低";
+"Command center mode 😳" = "指挥中心模式 😳";
+"So many sessions!" = "这么多 session！";
+"Full throttle" = "全力运转中";
+
+/* Reactive bubbles — hunger */
+"A little hungry…" = "有点饿了…";
+"Hmm… want food" = "嗯…想吃东西";
+"Tummy rumbling" = "肚子在打鼓";
+"Haven't been fed in a while 😢" = "好久没喂我了 😢";
+"Hungry…" = "饿了…";
+"Want food…" = "想吃东西…";
+"Where did you go… 😭" = "你去哪了… 😭";
+"About to faint from hunger" = "快要饿晕了";
+"So hungry" = "好饿啊";
+
+/* Reactive bubbles — streak */
+"Days in a row! Keep going" = "连续好几天！继续加油";
+"Going strong~" = "连续好几天了～";
+"Keeping it up" = "坚持住了";
+"A whole week straight!" = "整整一周没断过！";
+"Such persistence~" = "好有毅力～";
+"So consistent" = "太稳了";
+"Legendary streak!" = "传说级连续！";
+"Incredible!" = "太强了！";
+"Unstoppable" = "无人能挡";
+
+/* Reactive bubbles — daily meals */
+"Lots of sessions today~" = "今天完成了好多 session～";
+"Good productivity" = "效率不错";
+"Got quite a bit done" = "做了不少事";
+"Fifty sessions! Efficiency beast" = "五十个 session！效率怪物";
+"50+!" = "50+！";
+"Super productive" = "超高产";
+"Over 100! Not sleeping today?" = "破百！今天不睡了？";
+"100+ sessions!" = "100+ session！";
+"Superhuman" = "超人来的";
+
 /* HUD footer */
 "Settings" = "设置";
 "Updates" = "更新";

--- a/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/Localizations/zh-Hant.lproj/Localizable.strings
@@ -370,6 +370,73 @@
 "Opens buymeacoffee.com in your browser." = "在瀏覽器開啟 buymeacoffee.com。";
 "Quét bằng app ngân hàng bất kỳ (VPBank · NGUYEN THANH DAT)" = "用任意銀行 App 掃碼（VPBank · NGUYEN THANH DAT）";
 
+/* Reactive bubbles — settings */
+"Pet reactive bubbles" = "寵物反應氣泡";
+"Pet reacts to rate limits, token usage, hunger, and streaks." = "寵物會對速率限制、token 用量、飢餓度和連續天數作出反應。";
+
+/* Reactive bubbles — rate limit */
+"Usage is climbing~" = "用量開始升喇～";
+"Take it easy, no rush" = "慢慢嚟，唔急";
+"Keep an eye on quota" = "留意下 quota";
+"Rate limit running low…" = "Rate limit 快見底…";
+"Use sparingly!" = "要慳住用喇！";
+"Quota getting thin" = "Quota 唔多喇";
+"Almost out of quota 😰" = "差唔多冇 quota 喇 😰";
+"Maybe take a break…" = "停一停吖…";
+"Quota nearly spent" = "Quota 幾乎用完";
+
+/* Reactive bubbles — daily tokens */
+"Burned quite a few tokens today~" = "今日燒咗唔少 token～";
+"Eaten a lot of tokens" = "食咗好多 token 喇";
+"Token usage rising" = "Token 消耗上升中";
+"Big appetite mode!" = "大胃王模式！";
+"Great appetite today~" = "今日胃口好好～";
+"Tokens going fast" = "Token 食得好快";
+"Token usage off the charts today 🔥" = "今日 token 用量爆炸 🔥";
+"Token burn is extreme!" = "Token 消耗超高！";
+"Heavy burn today" = "今日 burn 好勁";
+
+/* Reactive bubbles — session count */
+"5 agents running at once~" = "5 個 agent 齊開～";
+"Lots of agents at work" = "好多 agent 喺度做嘢";
+"Parallelism is up" = "並行度唔低";
+"Command center mode 😳" = "指揮中心模式 😳";
+"So many sessions!" = "咁多 session！";
+"Full throttle" = "全力運作中";
+
+/* Reactive bubbles — hunger */
+"A little hungry…" = "有少少肚餓…";
+"Hmm… want food" = "嗯…想食嘢";
+"Tummy rumbling" = "肚子打鼓";
+"Haven't been fed in a while 😢" = "好耐冇餵我喇 😢";
+"Hungry…" = "肚餓…";
+"Want food…" = "想食嘢…";
+"Where did you go… 😭" = "你去咗邊… 😭";
+"About to faint from hunger" = "快要餓暈喇";
+"So hungry" = "好肚餓啊";
+
+/* Reactive bubbles — streak */
+"Days in a row! Keep going" = "連續幾日！繼續加油";
+"Going strong~" = "連續好幾日～";
+"Keeping it up" = "堅持緊";
+"A whole week straight!" = "成個禮拜冇斷過！";
+"Such persistence~" = "好有毅力～";
+"So consistent" = "太穩定喇";
+"Legendary streak!" = "傳說級連續！";
+"Incredible!" = "太強喇！";
+"Unstoppable" = "無人能擋";
+
+/* Reactive bubbles — daily meals */
+"Lots of sessions today~" = "今日完成好多 session～";
+"Good productivity" = "效率唔錯";
+"Got quite a bit done" = "做咗唔少嘢";
+"Fifty sessions! Efficiency beast" = "半百 session！效率怪物";
+"50+!" = "50+！";
+"Super productive" = "超高產";
+"Over 100! Not sleeping today?" = "破百！你今日唔駛瞓？";
+"100+ sessions!" = "100+ session！";
+"Superhuman" = "超人嚟嘅";
+
 /* HUD footer */
 "Settings" = "設定";
 "Updates" = "更新";

--- a/Sources/App/AppDaemon.swift
+++ b/Sources/App/AppDaemon.swift
@@ -41,6 +41,7 @@ final class AppDaemon: ObservableObject {
         pruneTimer = Timer.scheduledTimer(withTimeInterval: 10, repeats: true) { _ in
             Task { @MainActor [weak self] in self?.prune() }
         }
+        ReactiveEngine.shared.start()
     }
 
     /// Clears the tracked sessions (e.g. after disconnecting an integration).

--- a/Sources/App/BubbleSettings.swift
+++ b/Sources/App/BubbleSettings.swift
@@ -319,6 +319,9 @@ final class BubbleSettings: ObservableObject {
             ActivityFormatter.currentTheme = activityTheme
         }
     }
+    @Published var reactiveBubblesEnabled: Bool {
+        didSet { ud.set(reactiveBubblesEnabled, forKey: Keys.reactiveBubblesEnabled) }
+    }
 
     // MARK: Computed
 
@@ -357,6 +360,7 @@ final class BubbleSettings: ObservableObject {
         static let hiddenKinds         = "agentpet.bubble.hiddenKinds"
         static let iconChoices     = "agentpet.bubble.iconChoices"
         static let activityTheme   = "agentpet.bubble.activityTheme"
+        static let reactiveBubblesEnabled = "agentpet.bubble.reactiveBubblesEnabled"
     }
 
     init() {
@@ -372,6 +376,7 @@ final class BubbleSettings: ObservableObject {
         groupByKind     = ud.bool(forKey: Keys.groupByKind)
         displayMode = BubbleDisplayMode(rawValue: ud.string(forKey: Keys.displayMode) ?? "") ?? .carousel
         multiAgentBubbleEnabled = ud.object(forKey: Keys.multiAgentBubbleEnabled) as? Bool ?? true
+        reactiveBubblesEnabled = ud.object(forKey: Keys.reactiveBubblesEnabled) as? Bool ?? true
         hiddenKinds        = Set((Self.loadJSON(Keys.hiddenKinds) as [String]? ?? []).compactMap(AgentKind.init(rawValue:)))
         iconChoices    = Self.loadJSON(Keys.iconChoices) ?? [:]
         activityTheme  = ActivityTheme(rawValue: ud.string(forKey: Keys.activityTheme) ?? "") ?? .chef

--- a/Sources/App/BubbleSettingsView.swift
+++ b/Sources/App/BubbleSettingsView.swift
@@ -47,6 +47,15 @@ struct BubbleSettingsView: View {
                 Spacer()
                 ColorSwitch(isOn: $settings.multiAgentBubbleEnabled)
             }
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Pet reactive bubbles")
+                    Text("Pet reacts to rate limits, token usage, hunger, and streaks.")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+                Spacer()
+                ColorSwitch(isOn: $settings.reactiveBubblesEnabled)
+            }
         } header: {
             Text("Bubble mode")
         }

--- a/Sources/App/PetController.swift
+++ b/Sources/App/PetController.swift
@@ -170,6 +170,12 @@ final class PetController: ObservableObject {
         }
     }
 
+    func flashReactiveLine(_ line: String) {
+        guard showChat else { return }
+        chatLine = line
+        StatusBarController.shared.refreshTitle()
+    }
+
     private func setMood(_ newMood: PetMood) {
         let changed = newMood != mood
         mood = newMood

--- a/Sources/App/ReactiveEngine.swift
+++ b/Sources/App/ReactiveEngine.swift
@@ -55,28 +55,28 @@ private enum Thresholds {
 // MARK: - Phrase Pools
 
 private enum Phrases {
-    static let rateLimitLow = ["用量開始升喇～", "慢慢嚟，唔急", "留意下 quota"]
-    static let rateLimitHigh = ["Rate limit 快見底...", "要慳住用喇！", "Quota 唔多喇"]
-    static let rateLimitCritical = ["差唔多冇 quota 喇 😰", "停一停吖...", "Quota 幾乎用完"]
+    static let rateLimitLow = ["Usage is climbing~", "Take it easy, no rush", "Keep an eye on quota"]
+    static let rateLimitHigh = ["Rate limit running low…", "Use sparingly!", "Quota getting thin"]
+    static let rateLimitCritical = ["Almost out of quota 😰", "Maybe take a break…", "Quota nearly spent"]
 
-    static let dailyTokensLow = ["今日燒咗唔少 token～", "食咗好多 token 喇", "Token 消耗上升中"]
-    static let dailyTokensMid = ["大胃王模式！", "今日胃口好好～", "Token 食得好快"]
-    static let dailyTokensHigh = ["今日 token 用量爆炸 🔥", "Token 消耗超高！", "今日 burn 好勁"]
+    static let dailyTokensLow = ["Burned quite a few tokens today~", "Eaten a lot of tokens", "Token usage rising"]
+    static let dailyTokensMid = ["Big appetite mode!", "Great appetite today~", "Tokens going fast"]
+    static let dailyTokensHigh = ["Token usage off the charts today 🔥", "Token burn is extreme!", "Heavy burn today"]
 
-    static let sessionCountLow = ["5 個 agent 齊開～", "好多 agent 喺度做嘢", "並行度唔低"]
-    static let sessionCountHigh = ["指揮中心模式 😳", "咁多 session！", "全力運作中"]
+    static let sessionCountLow = ["5 agents running at once~", "Lots of agents at work", "Parallelism is up"]
+    static let sessionCountHigh = ["Command center mode 😳", "So many sessions!", "Full throttle"]
 
-    static let hungerLow = ["有少少肚餓...", "嗯...想食嘢", "肚子打鼓"]
-    static let hungerMid = ["好耐冇餵我喇 😢", "肚餓...", "想食嘢..."]
-    static let hungerHigh = ["你去咗邊... 😭", "快要餓暈喇", "好肚餓啊"]
+    static let hungerLow = ["A little hungry…", "Hmm… want food", "Tummy rumbling"]
+    static let hungerMid = ["Haven't been fed in a while 😢", "Hungry…", "Want food…"]
+    static let hungerHigh = ["Where did you go… 😭", "About to faint from hunger", "So hungry"]
 
-    static let streakLow = ["連續幾日！繼續加油", "連續好幾日～", "堅持緊"]
-    static let streakMid = ["成個禮拜冇斷過！", "好有毅力～", "太穩定喇"]
-    static let streakHigh = ["傳說級連續！", "太強喇！", "無人能擋"]
+    static let streakLow = ["Days in a row! Keep going", "Going strong~", "Keeping it up"]
+    static let streakMid = ["A whole week straight!", "Such persistence~", "So consistent"]
+    static let streakHigh = ["Legendary streak!", "Incredible!", "Unstoppable"]
 
-    static let dailyMealsLow = ["今日完成好多 session～", "效率唔錯", "做咗唔少嘢"]
-    static let dailyMealsMid = ["半百 session！效率怪物", "50+！", "超高產"]
-    static let dailyMealsHigh = ["破百！你今日唔駛瞓？", "100+ session！", "超人嚟嘅"]
+    static let dailyMealsLow = ["Lots of sessions today~", "Good productivity", "Got quite a bit done"]
+    static let dailyMealsMid = ["Fifty sessions! Efficiency beast", "50+!", "Super productive"]
+    static let dailyMealsHigh = ["Over 100! Not sleeping today?", "100+ sessions!", "Superhuman"]
 }
 
 // MARK: - CooldownTracker
@@ -149,7 +149,8 @@ public final class ReactiveEngine {
         guard let phrases = phrasePool(metric: metric, value: value) else { return nil }
         guard BubbleSettings.shared.reactiveBubblesEnabled else { return nil }
         guard cooldown.check(metric: metric, now: now) else { return nil }
-        return phrases.randomElement()
+        guard let phrase = phrases.randomElement() else { return nil }
+        return NSLocalizedString(phrase, comment: "reactive bubble")
     }
 
     // MARK: - Subscriptions

--- a/Sources/App/ReactiveEngine.swift
+++ b/Sources/App/ReactiveEngine.swift
@@ -1,0 +1,267 @@
+import Foundation
+import Combine
+import AgentPetCore
+
+// Re-export so test target (import agentpet) can use PetHunger without importing AgentPetCore directly
+public typealias PetHunger = AgentPetCore.PetHunger
+
+// MARK: - ReactiveMetric
+
+public enum ReactiveMetric: Hashable {
+    case rateLimit
+    case dailyTokens
+    case sessionCount
+    case hunger
+    case streak
+    case dailyMeals
+}
+
+// MARK: - Thresholds
+
+private enum Thresholds {
+    enum RateLimit {
+        static let silent: Double = 0.5
+        static let low: Double = 0.15
+        static let high: Double = 0.05
+    }
+    enum DailyTokens {
+        static let silent: Int = 1_000_000
+        static let low: Int = 3_000_000
+        static let mid: Int = 6_000_000
+    }
+    enum SessionCount {
+        static let silent: Int = 5
+        static let low: Int = 8
+    }
+    enum Streak {
+        static let silent: Int = 4
+        static let low: Int = 7
+        static let mid: Int = 14
+    }
+    enum DailyMeals {
+        static let silent: Int = 20
+        static let low: Int = 50
+        static let mid: Int = 100
+    }
+    enum Cooldown {
+        static let sameMetric: TimeInterval = 600
+        static let crossMetric: TimeInterval = 30
+    }
+    enum Hunger {
+        static let dailyLimit: Int = 2
+    }
+}
+
+// MARK: - Phrase Pools
+
+private enum Phrases {
+    static let rateLimitLow = ["用量開始升喇～", "慢慢嚟，唔急", "留意下 quota"]
+    static let rateLimitHigh = ["Rate limit 快見底...", "要慳住用喇！", "Quota 唔多喇"]
+    static let rateLimitCritical = ["差唔多冇 quota 喇 😰", "停一停吖...", "Quota 幾乎用完"]
+
+    static let dailyTokensLow = ["今日燒咗唔少 token～", "食咗好多 token 喇", "Token 消耗上升中"]
+    static let dailyTokensMid = ["大胃王模式！", "今日胃口好好～", "Token 食得好快"]
+    static let dailyTokensHigh = ["今日 token 用量爆炸 🔥", "Token 消耗超高！", "今日 burn 好勁"]
+
+    static let sessionCountLow = ["5 個 agent 齊開～", "好多 agent 喺度做嘢", "並行度唔低"]
+    static let sessionCountHigh = ["指揮中心模式 😳", "咁多 session！", "全力運作中"]
+
+    static let hungerLow = ["有少少肚餓...", "嗯...想食嘢", "肚子打鼓"]
+    static let hungerMid = ["好耐冇餵我喇 😢", "肚餓...", "想食嘢..."]
+    static let hungerHigh = ["你去咗邊... 😭", "快要餓暈喇", "好肚餓啊"]
+
+    static let streakLow = ["連續幾日！繼續加油", "連續好幾日～", "堅持緊"]
+    static let streakMid = ["成個禮拜冇斷過！", "好有毅力～", "太穩定喇"]
+    static let streakHigh = ["傳說級連續！", "太強喇！", "無人能擋"]
+
+    static let dailyMealsLow = ["今日完成好多 session～", "效率唔錯", "做咗唔少嘢"]
+    static let dailyMealsMid = ["半百 session！效率怪物", "50+！", "超高產"]
+    static let dailyMealsHigh = ["破百！你今日唔駛瞓？", "100+ session！", "超人嚟嘅"]
+}
+
+// MARK: - CooldownTracker
+
+private struct CooldownTracker {
+    private var lastFiredAt: [ReactiveMetric: Date] = [:]
+    private var lastAnyFiredAt: Date? = nil
+    private var hungerDayKey: String = ""
+    private var hungerDayCount: Int = 0
+
+    private static let utcCalendar: Calendar = {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        return cal
+    }()
+
+    private func dayKey(for date: Date) -> String {
+        let c = Self.utcCalendar.dateComponents([.year, .month, .day], from: date)
+        return String(format: "%04d-%02d-%02d", c.year ?? 0, c.month ?? 0, c.day ?? 0)
+    }
+
+    /// Returns true if allowed to fire. Mutates state if allowed.
+    mutating func check(metric: ReactiveMetric, now: Date) -> Bool {
+        // Same-metric gate takes priority
+        if let last = lastFiredAt[metric] {
+            if now.timeIntervalSince(last) < Thresholds.Cooldown.sameMetric {
+                return false
+            }
+        }
+
+        // Cross-metric gate: only applies when a *different* metric fired most recently
+        let lastAnyIsOtherMetric = lastAnyFiredAt != nil && lastAnyFiredAt != lastFiredAt[metric]
+        if lastAnyIsOtherMetric,
+           let lastAny = lastAnyFiredAt,
+           now.timeIntervalSince(lastAny) < Thresholds.Cooldown.crossMetric {
+            return false
+        }
+
+        // Hunger daily limit
+        if metric == .hunger {
+            let today = dayKey(for: now)
+            if hungerDayKey != today {
+                hungerDayKey = today
+                hungerDayCount = 0
+            }
+            if hungerDayCount >= Thresholds.Hunger.dailyLimit { return false }
+            hungerDayCount += 1
+        }
+
+        lastFiredAt[metric] = now
+        lastAnyFiredAt = now
+        return true
+    }
+}
+
+// MARK: - ReactiveEngine
+
+@MainActor
+public final class ReactiveEngine {
+
+    public static let shared = ReactiveEngine()
+
+    private var cooldown = CooldownTracker()
+    private var cancellables = Set<AnyCancellable>()
+
+    public init() {}
+
+    @discardableResult
+    public func evaluate(metric: ReactiveMetric, value: AnyHashable?, now: Date = .now) -> String? {
+        guard let phrases = phrasePool(metric: metric, value: value) else { return nil }
+        guard BubbleSettings.shared.reactiveBubblesEnabled else { return nil }
+        guard cooldown.check(metric: metric, now: now) else { return nil }
+        return phrases.randomElement()
+    }
+
+    // MARK: - Subscriptions
+
+    public func start() {
+        // Sink 1: OpenUsageClient
+        OpenUsageClient.shared.$providers
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                let value = OpenUsageClient.shared.lowestFractionLeft
+                if let line = self?.evaluate(metric: .rateLimit, value: value.map { AnyHashable($0) }) {
+                    PetController.shared.flashReactiveLine(line)
+                }
+            }
+            .store(in: &cancellables)
+
+        // Sink 2: PetCareController (evaluates 4 metrics)
+        PetCareController.shared.$states
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                let care = PetCareController.shared
+                let current = care.current
+
+                // dailyTokens — use days[todayKey] for real value
+                let todayKey = Self.todayKey()
+                let realTokens = current.days?[todayKey] ?? 0
+                if let line = self.evaluate(metric: .dailyTokens, value: AnyHashable(realTokens)) {
+                    PetController.shared.flashReactiveLine(line)
+                }
+
+                // streak
+                if let line = self.evaluate(metric: .streak, value: AnyHashable(current.streakDays)) {
+                    PetController.shared.flashReactiveLine(line)
+                }
+
+                // dailyMeals
+                if let line = self.evaluate(metric: .dailyMeals, value: AnyHashable(current.mealsToday)) {
+                    PetController.shared.flashReactiveLine(line)
+                }
+
+                // hunger
+                let hunger = care.hunger
+                if let line = self.evaluate(metric: .hunger, value: AnyHashable(hunger)) {
+                    PetController.shared.flashReactiveLine(line)
+                }
+            }
+            .store(in: &cancellables)
+
+        // Sink 3: AppDaemon sessions
+        AppDaemon.shared.$sessions
+            .receive(on: RunLoop.main)
+            .sink { [weak self] sessions in
+                if let line = self?.evaluate(metric: .sessionCount, value: AnyHashable(sessions.count)) {
+                    PetController.shared.flashReactiveLine(line)
+                }
+            }
+            .store(in: &cancellables)
+    }
+
+    private static func todayKey() -> String {
+        let c = Calendar.current.dateComponents([.year, .month, .day], from: Date())
+        return String(format: "%04d-%02d-%02d", c.year ?? 0, c.month ?? 0, c.day ?? 0)
+    }
+
+    // MARK: - Tier resolution
+
+    private func phrasePool(metric: ReactiveMetric, value: AnyHashable?) -> [String]? {
+        switch metric {
+        case .rateLimit:
+            guard let v = value.flatMap({ $0.base as? Double }) else { return nil }
+            if v > Thresholds.RateLimit.silent { return nil }
+            if v > Thresholds.RateLimit.low { return Phrases.rateLimitLow }
+            if v > Thresholds.RateLimit.high { return Phrases.rateLimitHigh }
+            return Phrases.rateLimitCritical
+
+        case .dailyTokens:
+            guard let v = value.flatMap({ $0.base as? Int }) else { return nil }
+            if v < Thresholds.DailyTokens.silent { return nil }
+            if v < Thresholds.DailyTokens.low { return Phrases.dailyTokensLow }
+            if v < Thresholds.DailyTokens.mid { return Phrases.dailyTokensMid }
+            return Phrases.dailyTokensHigh
+
+        case .sessionCount:
+            guard let v = value.flatMap({ $0.base as? Int }) else { return nil }
+            if v < Thresholds.SessionCount.silent { return nil }
+            if v < Thresholds.SessionCount.low { return Phrases.sessionCountLow }
+            return Phrases.sessionCountHigh
+
+        case .hunger:
+            guard let h = value.flatMap({ $0.base as? PetHunger }) else { return nil }
+            switch h {
+            case .full, .satisfied: return nil
+            case .peckish: return Phrases.hungerLow
+            case .hungry: return Phrases.hungerMid
+            case .starving: return Phrases.hungerHigh
+            }
+
+        case .streak:
+            guard let v = value.flatMap({ $0.base as? Int }) else { return nil }
+            if v < Thresholds.Streak.silent { return nil }
+            if v < Thresholds.Streak.low { return Phrases.streakLow }
+            if v < Thresholds.Streak.mid { return Phrases.streakMid }
+            return Phrases.streakHigh
+
+        case .dailyMeals:
+            guard let v = value.flatMap({ $0.base as? Int }) else { return nil }
+            if v < Thresholds.DailyMeals.silent { return nil }
+            if v < Thresholds.DailyMeals.low { return Phrases.dailyMealsLow }
+            if v < Thresholds.DailyMeals.mid { return Phrases.dailyMealsMid }
+            return Phrases.dailyMealsHigh
+        }
+    }
+}
+

--- a/Tests/AgentPetAppTests/ReactiveEngineTests.swift
+++ b/Tests/AgentPetAppTests/ReactiveEngineTests.swift
@@ -1,0 +1,282 @@
+import XCTest
+@testable import agentpet
+
+@MainActor
+final class ReactiveEngineTests: XCTestCase {
+
+    private func makeEngine() -> ReactiveEngine {
+        ReactiveEngine()
+    }
+
+    func testRateLimitAbove50PercentIsSilent() {
+        let engine = makeEngine()
+        let result = engine.evaluate(metric: .rateLimit, value: 0.6)
+        XCTAssertNil(result)
+    }
+
+    func testRateLimitBetween15And50PercentIsLow() {
+        let engine = makeEngine()
+        let result = engine.evaluate(metric: .rateLimit, value: 0.30)
+        XCTAssertNotNil(result)
+    }
+
+    func testRateLimitBetween5And15PercentIsHigh() {
+        let engine = makeEngine()
+        let result = engine.evaluate(metric: .rateLimit, value: 0.10)
+        XCTAssertNotNil(result)
+    }
+
+    func testRateLimitBelow5PercentIsCritical() {
+        let engine = makeEngine()
+        let result = engine.evaluate(metric: .rateLimit, value: 0.03)
+        XCTAssertNotNil(result)
+    }
+
+    func testRateLimitNilValueReturnsSilent() {
+        let engine = makeEngine()
+        let result = engine.evaluate(metric: .rateLimit, value: nil as Double?)
+        XCTAssertNil(result)
+    }
+
+    func testDailyTokensBelow1MIsSilent() {
+        let engine = makeEngine()
+        let result = engine.evaluate(metric: .dailyTokens, value: 800_000)
+        XCTAssertNil(result)
+    }
+
+    func testDailyTokensBetween1MAnd3MIsLow() {
+        let engine = makeEngine()
+        let result = engine.evaluate(metric: .dailyTokens, value: 2_000_000)
+        XCTAssertNotNil(result)
+    }
+
+    func testDailyTokensBetween3MAnd6MIsMid() {
+        let engine = makeEngine()
+        let result = engine.evaluate(metric: .dailyTokens, value: 4_500_000)
+        XCTAssertNotNil(result)
+    }
+
+    func testDailyTokensAbove6MIsHigh() {
+        let engine = makeEngine()
+        let result = engine.evaluate(metric: .dailyTokens, value: 7_000_000)
+        XCTAssertNotNil(result)
+    }
+
+    func testSessionCount1To4IsSilent() {
+        let engine = makeEngine()
+        let result = engine.evaluate(metric: .sessionCount, value: 3)
+        XCTAssertNil(result)
+    }
+
+    func testSessionCount5To7IsLow() {
+        let engine = makeEngine()
+        let result = engine.evaluate(metric: .sessionCount, value: 6)
+        XCTAssertNotNil(result)
+    }
+
+    func testSessionCount8OrMoreIsHigh() {
+        let engine = makeEngine()
+        let result = engine.evaluate(metric: .sessionCount, value: 8)
+        XCTAssertNotNil(result)
+    }
+
+    func testHungerFullIsSilent() {
+        let engine = makeEngine()
+        let result = engine.evaluate(metric: .hunger, value: PetHunger.full)
+        XCTAssertNil(result)
+    }
+
+    func testHungerSatisfiedIsSilent() {
+        let engine = makeEngine()
+        let result = engine.evaluate(metric: .hunger, value: PetHunger.satisfied)
+        XCTAssertNil(result)
+    }
+
+    func testHungerPeckishIsLow() {
+        let engine = makeEngine()
+        let result = engine.evaluate(metric: .hunger, value: PetHunger.peckish)
+        XCTAssertNotNil(result)
+    }
+
+    func testHungerHungryIsMid() {
+        let engine = makeEngine()
+        let result = engine.evaluate(metric: .hunger, value: PetHunger.hungry)
+        XCTAssertNotNil(result)
+    }
+
+    func testHungerStarvingIsHigh() {
+        let engine = makeEngine()
+        let result = engine.evaluate(metric: .hunger, value: PetHunger.starving)
+        XCTAssertNotNil(result)
+    }
+
+    func testStreak1To3IsSilent() {
+        let engine = makeEngine()
+        let result = engine.evaluate(metric: .streak, value: 2)
+        XCTAssertNil(result)
+    }
+
+    func testStreak4To6IsLow() {
+        let engine = makeEngine()
+        let result = engine.evaluate(metric: .streak, value: 5)
+        XCTAssertNotNil(result)
+    }
+
+    func testStreak7To13IsMid() {
+        let engine = makeEngine()
+        let result = engine.evaluate(metric: .streak, value: 10)
+        XCTAssertNotNil(result)
+    }
+
+    func testStreak14OrMoreIsHigh() {
+        let engine = makeEngine()
+        let result = engine.evaluate(metric: .streak, value: 14)
+        XCTAssertNotNil(result)
+    }
+
+    func testDailyMealsBelow20IsSilent() {
+        let engine = makeEngine()
+        let result = engine.evaluate(metric: .dailyMeals, value: 10)
+        XCTAssertNil(result)
+    }
+
+    func testDailyMeals20To50IsLow() {
+        let engine = makeEngine()
+        let result = engine.evaluate(metric: .dailyMeals, value: 35)
+        XCTAssertNotNil(result)
+    }
+
+    func testDailyMeals50To100IsMid() {
+        let engine = makeEngine()
+        let result = engine.evaluate(metric: .dailyMeals, value: 75)
+        XCTAssertNotNil(result)
+    }
+
+    func testDailyMeals100OrMoreIsHigh() {
+        let engine = makeEngine()
+        let result = engine.evaluate(metric: .dailyMeals, value: 100)
+        XCTAssertNotNil(result)
+    }
+
+    func testSameMetricBlockedWithin600Seconds() {
+        let engine = makeEngine()
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let first = engine.evaluate(metric: .dailyTokens, value: 2_000_000, now: now)
+        XCTAssertNotNil(first)
+        let secondNow = now.addingTimeInterval(599)
+        let second = engine.evaluate(metric: .dailyTokens, value: 2_000_000, now: secondNow)
+        XCTAssertNil(second)
+    }
+
+    func testSameMetricAllowedAfter600Seconds() {
+        let engine = makeEngine()
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        engine.evaluate(metric: .dailyTokens, value: 2_000_000, now: now)
+        let laterNow = now.addingTimeInterval(600)
+        let result = engine.evaluate(metric: .dailyTokens, value: 2_000_000, now: laterNow)
+        XCTAssertNotNil(result)
+    }
+
+    func testCrossMetricBlockedWithin30Seconds() {
+        let engine = makeEngine()
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        engine.evaluate(metric: .dailyTokens, value: 2_000_000, now: now)
+        let laterNow = now.addingTimeInterval(29)
+        let result = engine.evaluate(metric: .sessionCount, value: 6, now: laterNow)
+        XCTAssertNil(result)
+    }
+
+    func testCrossMetricAllowedAfter30Seconds() {
+        let engine = makeEngine()
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        engine.evaluate(metric: .dailyTokens, value: 2_000_000, now: now)
+        let laterNow = now.addingTimeInterval(30)
+        let result = engine.evaluate(metric: .sessionCount, value: 6, now: laterNow)
+        XCTAssertNotNil(result)
+    }
+
+    func testSameMetricGateTakesPriorityOverCrossMetricGate() {
+        let engine = makeEngine()
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        engine.evaluate(metric: .dailyTokens, value: 2_000_000, now: now)
+        let laterNow = now.addingTimeInterval(35)
+        let result = engine.evaluate(metric: .dailyTokens, value: 2_000_000, now: laterNow)
+        XCTAssertNil(result)
+    }
+
+    func testHungerDailyLimitBlocksThirdTriggerSameDay() {
+        let engine = makeEngine()
+        let base = Date(timeIntervalSince1970: 1_750_000_000)
+        let t1 = engine.evaluate(metric: .hunger, value: PetHunger.hungry, now: base)
+        XCTAssertNotNil(t1)
+        let t2 = engine.evaluate(metric: .hunger, value: PetHunger.hungry, now: base.addingTimeInterval(600))
+        XCTAssertNotNil(t2)
+        let t3 = engine.evaluate(metric: .hunger, value: PetHunger.hungry, now: base.addingTimeInterval(1200))
+        XCTAssertNil(t3)
+    }
+
+    func testHungerDailyLimitResetsNextDay() {
+        let engine = makeEngine()
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm"
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        let day1 = formatter.date(from: "2026-06-17 10:00")!
+        let day2 = formatter.date(from: "2026-06-18 10:00")!
+        engine.evaluate(metric: .hunger, value: PetHunger.hungry, now: day1)
+        engine.evaluate(metric: .hunger, value: PetHunger.hungry, now: day1.addingTimeInterval(600))
+        let blocked = engine.evaluate(metric: .hunger, value: PetHunger.hungry, now: day1.addingTimeInterval(1200))
+        XCTAssertNil(blocked)
+        let tomorrow = engine.evaluate(metric: .hunger, value: PetHunger.hungry, now: day2)
+        XCTAssertNotNil(tomorrow)
+    }
+
+    func testSilentTierReturnsNil() {
+        let engine = makeEngine()
+        let result = engine.evaluate(metric: .rateLimit, value: 0.9)
+        XCTAssertNil(result)
+    }
+
+    func testNonSilentTierReturnsNonNilString() {
+        let engine = makeEngine()
+        let result = engine.evaluate(metric: .streak, value: 14)
+        XCTAssertNotNil(result)
+        XCTAssertFalse(result?.isEmpty ?? true)
+    }
+
+    func testNilValueReturnsNil() {
+        let engine = makeEngine()
+        let result = engine.evaluate(metric: .rateLimit, value: nil as Double?)
+        XCTAssertNil(result)
+    }
+
+    func testCooldownBlockReturnsNil() {
+        let engine = makeEngine()
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let first = engine.evaluate(metric: .streak, value: 14, now: now)
+        XCTAssertNotNil(first)
+        let second = engine.evaluate(metric: .streak, value: 14, now: now.addingTimeInterval(1))
+        XCTAssertNil(second)
+    }
+}
+
+private extension ReactiveEngine {
+    @discardableResult
+    func evaluate(metric: ReactiveMetric, value: Double?, now: Date = .now) -> String? {
+        evaluate(metric: metric, value: value.map { AnyHashable($0) }, now: now)
+    }
+
+    @discardableResult
+    func evaluate(metric: ReactiveMetric, value: Double, now: Date = .now) -> String? {
+        evaluate(metric: metric, value: AnyHashable(value), now: now)
+    }
+
+    @discardableResult
+    func evaluate(metric: ReactiveMetric, value: Int, now: Date = .now) -> String? {
+        evaluate(metric: metric, value: AnyHashable(value), now: now)
+    }
+
+    @discardableResult
+    func evaluate(metric: ReactiveMetric, value: PetHunger, now: Date = .now) -> String? {
+        evaluate(metric: metric, value: AnyHashable(value), now: now)
+    }
+}


### PR DESCRIPTION
## Summary

- Pet reacts to **6 global metrics** via speech bubbles: rate limit, daily token usage, session count, hunger, streak days, and daily meals
- Powered entirely by **existing `@Published` data sources** (`OpenUsageClient`, `PetCareController`, `AppDaemon`) — zero new extraction logic
- Tiered phrase pools (silent → low → mid → high) with **cooldown tracking** (same-metric ≥10min, cross-metric ≥30s, hunger max 2/day) to prevent notification spam
- New "Pet Reactive Bubbles" toggle in Settings → Bubble (default ON)
- 36 unit tests covering all threshold boundaries and cooldown gate logic

## Design details

| Component | Implementation |
|-----------|---------------|
| ReactiveEngine | `@MainActor` singleton, Combine sinks on 3 existing publishers |
| Thresholds | Static constants in `Thresholds` namespace, table-driven tier resolution |
| Cooldown | Per-metric + cross-metric + hunger daily limit, UTC day-key tracking |
| UI integration | `PetController.flashReactiveLine(_:)` — respects `showChat`, never changes pet mood |
| Settings | `BubbleSettings.reactiveBubblesEnabled` persisted in UserDefaults |

## Test plan

- [x] `swift build` — compiles cleanly
- [x] `swift test` — 186 tests, 0 failures, no regressions
- [ ] Manual: wait for rate limit to drop below 50% → pet shows rate limit reaction bubble
- [ ] Manual: accumulate >1M tokens in a day → pet shows token usage reaction
- [ ] Manual: open 5+ concurrent agent sessions → pet shows session count reaction
- [ ] Manual: toggle OFF "Pet Reactive Bubbles" in Settings → no more reactive bubbles appear
- [ ] Manual: toggle OFF "Show chat" → reactive bubbles also suppressed