### PR TITLE
Pet improvements: per-project pets, break reminder, moods, and CPU perf

### DIFF
--- a/Sources/AgentPetCore/BreakClock.swift
+++ b/Sources/AgentPetCore/BreakClock.swift
@@ -1,0 +1,102 @@
+// Sources/AgentPetCore/BreakClock.swift
+import Foundation
+
+/// Config for `BreakClock`. The app layer rebuilds this from settings each tick
+/// so changes apply immediately.
+public struct BreakClockConfig: Equatable, Sendable {
+    public var enabled: Bool
+    /// Seconds of continuous active work before a break is due.
+    public var workInterval: TimeInterval
+    /// Seconds the rest window lasts; also the absence that counts as a break taken.
+    public var breakLength: TimeInterval
+    /// A gap between ticks larger than this means the machine slept / the app
+    /// stalled — treat as away, reset, and don't fire a stale break.
+    public var maxDelta: TimeInterval
+
+    public init(enabled: Bool, workInterval: TimeInterval,
+                breakLength: TimeInterval, maxDelta: TimeInterval) {
+        self.enabled = enabled
+        self.workInterval = workInterval
+        self.breakLength = breakLength
+        self.maxDelta = maxDelta
+    }
+}
+
+/// What a tick decided.
+public enum BreakTick: Equatable, Sendable {
+    case none
+    case breakDue
+    case breakOver
+}
+
+/// Pure, deterministic break-timing core. No wall-clock or IO reads — the caller
+/// passes `now` and whether the user is present each tick (mirrors `SessionStore`
+/// and `PerKeyThrottle`). Accumulates continuous active time; a long absence
+/// resets the clock (counts as a break already taken), so it never nags after
+/// the user steps away.
+public final class BreakClock {
+    private enum Phase: Equatable {
+        case working
+        case resting(since: Date)
+    }
+
+    private var phase: Phase = .working
+    private var activeSeconds: TimeInterval = 0
+    private var absenceSeconds: TimeInterval = 0
+    private var lastTick: Date?
+
+    public init() {}
+
+    /// Clears all timing state (e.g. when the feature is toggled off / on).
+    public func reset() {
+        phase = .working
+        activeSeconds = 0
+        absenceSeconds = 0
+        lastTick = nil
+    }
+
+    /// Advances the clock. `isPresent` = the user did something this tick (input
+    /// or an active agent). Returns the action the driver should take.
+    public func tick(now: Date, isPresent: Bool, config: BreakClockConfig) -> BreakTick {
+        guard config.enabled else { reset(); return .none }
+
+        let delta = lastTick.map { now.timeIntervalSince($0) } ?? 0
+        lastTick = now
+
+        // Sleep / long stall: treat as away, reset, no stale break.
+        if delta > config.maxDelta {
+            phase = .working
+            activeSeconds = 0
+            absenceSeconds = 0
+            return .none
+        }
+
+        switch phase {
+        case .resting(let since):
+            if now.timeIntervalSince(since) >= config.breakLength {
+                phase = .working
+                activeSeconds = 0
+                absenceSeconds = 0
+                return .breakOver
+            }
+            return .none   // rest is rest; ignore presence during the window
+
+        case .working:
+            if isPresent {
+                absenceSeconds = 0
+                activeSeconds += delta
+                if activeSeconds >= config.workInterval {
+                    phase = .resting(since: now)
+                    return .breakDue
+                }
+            } else {
+                absenceSeconds += delta
+                if absenceSeconds >= config.breakLength {   // auto-credit a break
+                    activeSeconds = 0
+                    absenceSeconds = 0
+                }
+            }
+            return .none
+        }
+    }
+}

--- a/Sources/AgentPetCore/EventSocketServer.swift
+++ b/Sources/AgentPetCore/EventSocketServer.swift
@@ -68,11 +68,49 @@ public final class EventSocketServer: @unchecked Sendable {
         unlink(path)
     }
 
+    /// What the accept loop should do after `accept()` returns an error.
+    enum AcceptErrorAction: Equatable {
+        /// Transient, expected error (interrupted syscall, client aborted) —
+        /// loop again right away.
+        case retryImmediately
+        /// Recoverable resource pressure (fd exhaustion) or an unknown error —
+        /// sleep briefly before retrying so a *persistent* error can't spin a
+        /// CPU core at 100%.
+        case backoff
+        /// The listen socket itself is gone (closed/invalid) — retrying can
+        /// only ever fail again, so stop the loop instead of spinning.
+        case stop
+    }
+
+    /// Classifies an `accept()` errno. The default is `.backoff`, never
+    /// `.retryImmediately`: an unrecognised error must not fall through to a
+    /// tight, CPU-pegging retry loop.
+    static func acceptErrorAction(errno code: Int32) -> AcceptErrorAction {
+        switch code {
+        case EINTR, ECONNABORTED:
+            return .retryImmediately
+        case EBADF, EINVAL, ENOTSOCK:
+            return .stop
+        default:
+            return .backoff
+        }
+    }
+
     private func acceptLoop(onEvent: @escaping @Sendable (AgentEvent) -> Void) {
         while running {
             let client = accept(listenFD, nil, nil)
             if client < 0 {
-                if running { continue } else { break }
+                let err = errno
+                guard running else { break }
+                switch Self.acceptErrorAction(errno: err) {
+                case .retryImmediately:
+                    continue
+                case .backoff:
+                    usleep(50_000)   // 50ms — cap a persistent error at ~20 retries/sec
+                    continue
+                case .stop:
+                    return
+                }
             }
             handleClient(client, onEvent: onEvent)
         }

--- a/Sources/AgentPetCore/PerKeyThrottle.swift
+++ b/Sources/AgentPetCore/PerKeyThrottle.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Deterministic per-key rate limiter. `shouldRun(_:now:)` returns `true` at
+/// most once per `interval` for a given key, recording when it last allowed a
+/// run. Free of wall-clock reads (callers pass `now`) so behaviour is testable.
+///
+/// Used to collapse per-event transcript work (title/model resolution) that
+/// would otherwise re-read and re-parse the transcript on every hook event,
+/// pegging the CPU during heavy agent activity.
+public final class PerKeyThrottle {
+    private let interval: TimeInterval
+    private var lastRun: [String: Date] = [:]
+
+    public init(interval: TimeInterval) {
+        self.interval = interval
+    }
+
+    public func shouldRun(_ key: String, now: Date) -> Bool {
+        if let last = lastRun[key], now.timeIntervalSince(last) < interval {
+            return false
+        }
+        lastRun[key] = now
+        return true
+    }
+}

--- a/Sources/AgentPetCore/PetMood.swift
+++ b/Sources/AgentPetCore/PetMood.swift
@@ -8,6 +8,10 @@ public enum PetMood: String, Codable, Sendable, CaseIterable {
     case waiting
     case done
     case celebrate
+    /// Resting during a break reminder (app-layer override, not a session state).
+    case sleepy
+    /// Transient burst when the pet levels up (app-layer transient, like celebrate).
+    case levelup
 }
 
 /// Reduces all sessions to a single mood by attention priority.

--- a/Sources/AgentPetCore/PetWindowPlanner.swift
+++ b/Sources/AgentPetCore/PetWindowPlanner.swift
@@ -16,8 +16,21 @@ public enum PetWindowPlanner {
         s == .working || s == .waiting || s == .done
     }
 
+    /// Plans the per-project pet windows. `forceDefault` guarantees a home
+    /// ("default") window in the result even in split mode — used so a break
+    /// nudge always has a pet to show.
     public static func plan(sessions: [AgentSession], split: Bool,
-                            mappings: [ProjectPetMapping], defaultPetID: String?) -> [PetWindowSpec] {
+                            mappings: [ProjectPetMapping], defaultPetID: String?,
+                            forceDefault: Bool = false) -> [PetWindowSpec] {
+        let specs = planCore(sessions: sessions, split: split,
+                             mappings: mappings, defaultPetID: defaultPetID)
+        guard forceDefault, !specs.contains(where: { $0.key == defaultKey }) else { return specs }
+        return specs + [PetWindowSpec(key: defaultKey, projectName: nil, petID: defaultPetID,
+                                      sessionIDs: [], mood: .idle, count: 0)]
+    }
+
+    private static func planCore(sessions: [AgentSession], split: Bool,
+                                 mappings: [ProjectPetMapping], defaultPetID: String?) -> [PetWindowSpec] {
         let active = sessions.filter { isActive($0.state) }
 
         func homeIdle() -> [PetWindowSpec] {

--- a/Sources/AgentPetCore/PetWindowPlanner.swift
+++ b/Sources/AgentPetCore/PetWindowPlanner.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+public struct PetWindowSpec: Equatable, Sendable {
+    public var key: String
+    public var projectName: String?
+    public var petID: String?
+    public var sessionIDs: [String]
+    public var mood: PetMood
+    public var count: Int
+}
+
+public enum PetWindowPlanner {
+    public static let defaultKey = "default"
+
+    private static func isActive(_ s: AgentState) -> Bool {
+        s == .working || s == .waiting || s == .done
+    }
+
+    public static func plan(sessions: [AgentSession], split: Bool,
+                            mappings: [ProjectPetMapping], defaultPetID: String?) -> [PetWindowSpec] {
+        let active = sessions.filter { isActive($0.state) }
+
+        func homeIdle() -> [PetWindowSpec] {
+            [PetWindowSpec(key: defaultKey, projectName: nil, petID: defaultPetID,
+                           sessionIDs: [], mood: .idle, count: 0)]
+        }
+
+        if !split {
+            guard !active.isEmpty else { return homeIdle() }
+            return [PetWindowSpec(key: defaultKey, projectName: nil, petID: defaultPetID,
+                                  sessionIDs: active.map(\.id),
+                                  mood: MoodResolver.aggregate(active), count: active.count)]
+        }
+
+        guard !active.isEmpty else { return homeIdle() }
+
+        // group active sessions by key
+        var groups: [String: (petID: String?, sessions: [AgentSession])] = [:]
+        for s in active {
+            let key: String
+            let petID: String?
+            if let m = ProjectPetResolver.mapping(forProject: s.project, mappings: mappings) {
+                key = ProjectPetResolver.normalize(m.projectPath); petID = m.petID
+            } else if let p = s.project, !p.isEmpty {
+                key = ProjectPetResolver.normalize(p); petID = defaultPetID
+            } else {
+                key = defaultKey; petID = defaultPetID
+            }
+            groups[key, default: (petID, [])].sessions.append(s)
+            groups[key]!.petID = petID
+        }
+
+        return groups.keys.sorted().map { key in
+            let g = groups[key]!
+            return PetWindowSpec(
+                key: key,
+                projectName: key == defaultKey ? nil : (key as NSString).lastPathComponent,
+                petID: g.petID,
+                sessionIDs: g.sessions.map(\.id),
+                mood: MoodResolver.aggregate(g.sessions),
+                count: g.sessions.count)
+        }
+    }
+}

--- a/Sources/AgentPetCore/ProjectPetMapping.swift
+++ b/Sources/AgentPetCore/ProjectPetMapping.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public struct ProjectPetMapping: Codable, Equatable, Sendable {
+    public var projectPath: String
+    public var petID: String
+    public init(projectPath: String, petID: String) {
+        self.projectPath = projectPath
+        self.petID = petID
+    }
+}

--- a/Sources/AgentPetCore/ProjectPetResolver.swift
+++ b/Sources/AgentPetCore/ProjectPetResolver.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public enum ProjectPetResolver {
+    /// Most-specific (longest projectPath) mapping whose folder contains `cwd`.
+    public static func mapping(forProject cwd: String?,
+                               mappings: [ProjectPetMapping]) -> ProjectPetMapping? {
+        guard let cwd, !cwd.isEmpty else { return nil }
+        let target = normalize(cwd)
+        return mappings
+            .filter { contains(root: normalize($0.projectPath), path: target) }
+            .max { normalize($0.projectPath).count < normalize($1.projectPath).count }
+    }
+
+    /// True when `path` equals `root` or is a descendant directory of `root`.
+    /// Boundary-aware: "/work/foo" does not contain "/work/foobar".
+    static func contains(root: String, path: String) -> Bool {
+        if path == root { return true }
+        return path.hasPrefix(root + "/")
+    }
+
+    /// Strips a trailing slash and standardises the path.
+    public static func normalize(_ path: String) -> String {
+        let std = (path as NSString).standardizingPath
+        if std.count > 1 && std.hasSuffix("/") { return String(std.dropLast()) }
+        return std
+    }
+}

--- a/Sources/App/AgentPetApp.swift
+++ b/Sources/App/AgentPetApp.swift
@@ -35,6 +35,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         OpenUsageClient.shared.start()
         NativeUsageProbe.shared.start()
         CareSyncController.shared.start()
+        BreakReminderController.shared.start()
         SettingsModel.shared.migrateInstalledHooksIfNeeded()
         SettingsModel.shared.repairStaleHookPathsIfNeeded()
         updater = UpdaterController.shared

--- a/Sources/App/AppDaemon.swift
+++ b/Sources/App/AppDaemon.swift
@@ -131,6 +131,10 @@ final class AppDaemon: ObservableObject {
     }
 
     private func resolveTitle(for event: AgentEvent) {
+        // A title, once resolved, is stable — stop re-reading the transcript
+        // head on every subsequent event. Without this the transcript was
+        // re-read and re-parsed on every hook event of a session.
+        guard store.session(id: event.sessionId)?.title == nil else { return }
         let sessionId = event.sessionId
         let path: String? = event.transcriptPath
             ?? event.project.map { TranscriptReader.inferredPath(sessionId: sessionId, cwd: $0) }
@@ -147,8 +151,15 @@ final class AppDaemon: ObservableObject {
     /// Reads the transcript off-thread for the model of the latest assistant
     /// message — picks up `/model` switches mid-session, which Claude's hook
     /// payloads only report at `SessionStart`.
+    /// Reading the transcript tail to detect a `/model` switch is the heaviest
+    /// per-event work (128 KB read + JSON parse per line). The model rarely
+    /// changes mid-session and its initial value already comes from the hook
+    /// payload, so throttle this hard rather than running it on every event.
+    private let modelResolveThrottle = PerKeyThrottle(interval: 30)
+
     private func resolveModel(for event: AgentEvent) {
         guard event.agentKind == .claude else { return }
+        guard modelResolveThrottle.shouldRun(event.sessionId, now: Date()) else { return }
         let sessionId = event.sessionId
         let path: String? = event.transcriptPath
             ?? event.project.map { TranscriptReader.inferredPath(sessionId: sessionId, cwd: $0) }

--- a/Sources/App/AppDaemon.swift
+++ b/Sources/App/AppDaemon.swift
@@ -77,6 +77,15 @@ final class AppDaemon: ObservableObject {
         refresh()
     }
 
+    /// Resolves which pet should receive XP for a given project path.
+    /// Split ON  → the project's configured pet (or the selected pet if unconfigured).
+    /// Split OFF → always the selected pet (identical to today's behaviour).
+    func careTarget(forProject project: String?) -> String? {
+        guard PetController.shared.splitPet else { return PetController.shared.selectedPetID }
+        return ProjectPetSettings.shared.petID(forProject: project)
+            ?? PetController.shared.selectedPetID
+    }
+
     /// Tokens appear in the transcript while Claude is still working, so the
     /// pet eats live on tool events instead of waiting for `Stop`. Throttled
     /// per session; reads are incremental (offset-based), so the `Stop` path
@@ -93,10 +102,16 @@ final class AppDaemon: ObservableObject {
         if let last = lastLiveFeed[event.sessionId],
            now.timeIntervalSince(last) < Self.liveFeedInterval { return }
         lastLiveFeed[event.sessionId] = now
+        // Capture the project string (Sendable) before crossing the actor boundary;
+        // resolve careTarget on the main actor inside the awaited block.
+        let project = event.project
         Task.detached(priority: .utility) {
             let tokens = TranscriptReader.newUsageTokens(at: path) ?? 0
             guard tokens > 0 else { return }
-            await MainActor.run { PetCareController.shared.feedTokens(tokens) }
+            await MainActor.run {
+                PetCareController.shared.feedTokens(tokens,
+                    petID: AppDaemon.shared.careTarget(forProject: project))
+            }
         }
     }
 
@@ -112,6 +127,8 @@ final class AppDaemon: ObservableObject {
             notifyIfNeeded(before: before, session: session)
             return
         }
+        // Capture the project string (Sendable) before crossing the actor boundary.
+        let project = session.project
         Task.detached(priority: .utility) { [weak self] in
             let isQuestion = TranscriptReader.latestAssistantText(at: path)
                 .map(QuestionDetector.looksLikeQuestion) ?? false
@@ -119,7 +136,8 @@ final class AppDaemon: ObservableObject {
             let tokens = TranscriptReader.newUsageTokens(at: path) ?? 0
             await MainActor.run { [weak self] in
                 guard let self else { return }
-                PetCareController.shared.feedTokens(tokens)
+                PetCareController.shared.feedTokens(tokens,
+                    petID: self.careTarget(forProject: project))
                 if isQuestion {
                     self.store.refineState(id: sessionId, from: .done, to: .waiting, since: stateSince)
                 }
@@ -185,7 +203,7 @@ final class AppDaemon: ObservableObject {
             NotificationManager.shared.notify(
                 title: "\(project) finished", body: "Agent completed its turn")
             SoundSettings.shared.play(.done)
-            PetCareController.shared.recordMeal()
+            PetCareController.shared.recordMeal(petID: careTarget(forProject: session.project))
         default:
             break
         }

--- a/Sources/App/BreakReminderController.swift
+++ b/Sources/App/BreakReminderController.swift
@@ -1,0 +1,78 @@
+// Sources/App/BreakReminderController.swift
+import AppKit
+import AgentPetCore
+
+/// Drives the break reminder: a low-rate timer reads whether the user is present
+/// (input activity or an active agent), advances the pure `BreakClock`, and
+/// nudges the default pet to rest when a break is due. The timer only runs while
+/// the feature is enabled, so a disabled reminder costs nothing.
+@MainActor
+final class BreakReminderController {
+    static let shared = BreakReminderController()
+
+    private let clock = BreakClock()
+    private let settings = BreakReminderSettings.shared
+    private var timer: Timer?
+
+    private static let tickInterval: TimeInterval = 60
+    /// A gap larger than this between ticks means the machine slept / the app
+    /// stalled — `BreakClock` resets instead of firing a stale break.
+    private static let maxDelta: TimeInterval = 300
+
+    func start() {
+        settings.onChange = { [weak self] in self?.applyEnabled() }
+        applyEnabled()
+    }
+
+    /// Starts or stops the tick timer to match the enabled flag, resetting the
+    /// clock on every flip so a re-enable counts from zero.
+    private func applyEnabled() {
+        clock.reset()
+        PetController.shared.cancelBreakRest()
+        timer?.invalidate()
+        timer = nil
+        guard settings.enabled else { return }
+        let t = Timer(timeInterval: Self.tickInterval, repeats: true) { _ in
+            Task { @MainActor [weak self] in self?.tick() }
+        }
+        RunLoop.main.add(t, forMode: .common)
+        timer = t
+    }
+
+    private func config() -> BreakClockConfig {
+        BreakClockConfig(
+            enabled: settings.enabled,
+            workInterval: TimeInterval(settings.workIntervalMinutes) * 60,
+            breakLength: TimeInterval(settings.breakLengthMinutes) * 60,
+            maxDelta: Self.maxDelta
+        )
+    }
+
+    /// Present if the user generated input within the last tick OR an agent is
+    /// actively running (you may be watching a long run without touching keys).
+    private func isPresent() -> Bool {
+        // kCGAnyInputEventType (UInt32.max) covers all input classes.
+        let anyInput = CGEventType(rawValue: UInt32.max)!
+        let idle = CGEventSource.secondsSinceLastEventType(.combinedSessionState, eventType: anyInput)
+        if idle < Self.tickInterval { return true }
+        return AppDaemon.shared.sessions.contains { $0.state == .working || $0.state == .waiting }
+    }
+
+    private func tick() {
+        switch clock.tick(now: Date(), isPresent: isPresent(), config: config()) {
+        case .none:
+            break
+        case .breakDue:
+            let mins = settings.workIntervalMinutes
+            let brk = settings.breakLengthMinutes
+            NotificationManager.shared.notify(
+                title: "Time for a break",
+                body: "You've worked \(mins) min — rest \(brk) min 😴")
+            NSSound(named: "Purr")?.play()
+            PetController.shared.beginBreakRest(
+                line: "Worked \(mins) min — let's rest \(brk) min 😴")
+        case .breakOver:
+            PetController.shared.endBreakRest(line: "Break's over — back to it! 💪")
+        }
+    }
+}

--- a/Sources/App/BreakReminderSettings.swift
+++ b/Sources/App/BreakReminderSettings.swift
@@ -1,0 +1,34 @@
+// Sources/App/BreakReminderSettings.swift
+import Foundation
+
+/// User config for the break reminder (tab General). UserDefaults-backed and
+/// `@Published`, matching the other settings objects. `onChange` lets the
+/// controller (re)start its timer whenever a value flips.
+@MainActor
+final class BreakReminderSettings: ObservableObject {
+    static let shared = BreakReminderSettings()
+
+    @Published var enabled: Bool {
+        didSet { UserDefaults.standard.set(enabled, forKey: Self.enabledKey); onChange?() }
+    }
+    @Published var workIntervalMinutes: Int {
+        didSet { UserDefaults.standard.set(workIntervalMinutes, forKey: Self.workKey); onChange?() }
+    }
+    @Published var breakLengthMinutes: Int {
+        didSet { UserDefaults.standard.set(breakLengthMinutes, forKey: Self.breakKey); onChange?() }
+    }
+
+    /// Invoked on any change so `BreakReminderController` can react.
+    var onChange: (() -> Void)?
+
+    private static let enabledKey = "agentpet.breakReminder.enabled"
+    private static let workKey = "agentpet.breakReminder.workIntervalMinutes"
+    private static let breakKey = "agentpet.breakReminder.breakLengthMinutes"
+
+    init() {
+        let d = UserDefaults.standard
+        enabled = (d.object(forKey: Self.enabledKey) as? Bool) ?? false
+        workIntervalMinutes = (d.object(forKey: Self.workKey) as? Int) ?? 90
+        breakLengthMinutes = (d.object(forKey: Self.breakKey) as? Int) ?? 5
+    }
+}

--- a/Sources/App/BubbleMessages.swift
+++ b/Sources/App/BubbleMessages.swift
@@ -49,6 +49,8 @@ final class BubbleMessages: ObservableObject {
         case .celebrate: base = PetChat.lines[.celebrate] ?? []
         case .idle:      base = IdleBoost.lines
         case .working:   base = []
+        case .sleepy:    base = IdleBoost.lines
+        case .levelup:   base = PetChat.lines[.celebrate] ?? []
         }
         return base.map { NSLocalizedString($0, comment: "bubble message") }
     }

--- a/Sources/App/BubbleSettingsView.swift
+++ b/Sources/App/BubbleSettingsView.swift
@@ -203,6 +203,8 @@ struct BubbleSettingsView: View {
         case .done:      return NSLocalizedString("Done", comment: "pet mood")
         case .celebrate: return NSLocalizedString("Celebrate", comment: "pet mood")
         case .idle:      return NSLocalizedString("Idle", comment: "pet mood")
+        case .sleepy:    return NSLocalizedString("Sleepy", comment: "pet mood")
+        case .levelup:   return NSLocalizedString("Level up", comment: "pet mood")
         }
     }
 

--- a/Sources/App/ImageSpriteView.swift
+++ b/Sources/App/ImageSpriteView.swift
@@ -1,50 +1,153 @@
 import SwiftUI
+import AppKit
 import AgentPetCore
 
-/// Renders an imported spritesheet pet: cycles its frames and applies the same
-/// mood motion and overlays as the built-in pets. Frame rate varies by mood
-/// (faster while working) since image packs carry no per-mood data.
+/// Renders an imported spritesheet pet. The frame cycling runs in a CALayer
+/// (see `SpriteLayerNSView`), NOT a SwiftUI `TimelineView`: a SwiftUI timeline
+/// re-evaluates and re-renders the whole view tree every tick, and an
+/// always-on-screen pet (×every window) made that the dominant CPU cost.
+/// Swapping `layer.contents` on a timer animates in Core Animation instead, so
+/// SwiftUI does not redraw the sprite per frame. The only SwiftUI animation
+/// left here is the transient celebrate sparkle overlay (≈3s, mood `.celebrate`).
 struct ImageSpriteView: View {
     /// Frames of the clip bound to the current mood (resolved by the caller).
     let frames: [NSImage]
     let mood: PetMood
+    /// Sprite frame rate supplied by the caller (from `PetController.spriteFPS(forMood:)`).
+    let fps: Double
     var size: CGFloat = 110
+    @Environment(\.animationsEnabled) private var animationsEnabled
 
     var body: some View {
-        TimelineView(.animation(minimumInterval: 1.0 / 12.0)) { context in
-            let t = context.date.timeIntervalSinceReferenceDate
-            let m = PetMotion.resolve(mood, t)
-
-            ZStack {
-                MoodAccessories(mood: mood, t: t, size: size)
-
-                frameImage(at: t)
-                    .rotationEffect(.degrees(m.rotation), anchor: .bottom)
-                    .scaleEffect(x: m.scaleX, y: m.scaleY, anchor: .bottom)
-                    .offset(y: m.offsetY)
+        ZStack {
+            // Sparkles only exist for `.celebrate`, and celebrate is a short
+            // transient — gate the (animated) overlay on it so idle/working
+            // states carry no perpetual SwiftUI animation at all.
+            // When animations are disabled, skip the celebrate overlay entirely.
+            if mood == .celebrate && animationsEnabled {
+                TimelineView(.periodic(from: .now, by: 1.0 / 8.0)) { context in
+                    MoodAccessories(mood: mood,
+                                    t: context.date.timeIntervalSinceReferenceDate,
+                                    size: size)
+                }
             }
-            .frame(width: size, height: size)
+
+            if frames.isEmpty {
+                Image(systemName: "pawprint.fill").font(.system(size: 36))
+            } else {
+                SpriteLayer(frames: frames, fps: fps, size: size, animate: animationsEnabled)
+                    .frame(width: size, height: size)
+            }
+        }
+        .frame(width: size, height: size)
+    }
+}
+
+/// SwiftUI bridge to the CALayer-backed sprite player.
+private struct SpriteLayer: NSViewRepresentable {
+    let frames: [NSImage]
+    let fps: Double
+    let size: CGFloat
+    var animate: Bool = true
+
+    func makeNSView(context: Context) -> SpriteLayerNSView {
+        let view = SpriteLayerNSView()
+        view.configure(frames: frames, fps: fps, animate: animate)
+        return view
+    }
+
+    func updateNSView(_ view: SpriteLayerNSView, context: Context) {
+        // Called on every SwiftUI re-render of the parent (which, while a chat
+        // bubble's perpetual animations run, can be ~display-rate). `configure`
+        // is idempotent: it only rebuilds frames / restarts the timer when the
+        // frames or fps actually change, so this never churns the timer.
+        view.configure(frames: frames, fps: fps, animate: animate)
+    }
+
+    static func dismantleNSView(_ view: SpriteLayerNSView, coordinator: ()) {
+        view.teardown()
+    }
+}
+
+/// A layer-backed view that cycles CGImages by swapping `layer.contents` on a
+/// timer at `fps`. No SwiftUI involvement per frame.
+final class SpriteLayerNSView: NSView {
+    private var cgFrames: [CGImage] = []
+    private var sourceFrames: [NSImage] = []
+    private var fps: Double = 3
+    private var animate: Bool = true
+    private var index = 0
+    private var timer: Timer?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.contentsGravity = .resizeAspect
+        layer?.magnificationFilter = .linear
+        layer?.minificationFilter = .linear
+        layer?.contentsScale = window?.backingScaleFactor ?? 2
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) not used") }
+
+    func configure(frames: [NSImage], fps: Double, animate: Bool = true) {
+        let framesChanged = frames.count != sourceFrames.count
+            || !zip(frames, sourceFrames).allSatisfy { $0 === $1 }
+        if framesChanged {
+            sourceFrames = frames
+            cgFrames = frames.compactMap { $0.cgImage(forProposedRect: nil, context: nil, hints: nil) }
+            index = 0
+        }
+        let fpsChanged = fps != self.fps
+        self.fps = fps
+        let animateChanged = animate != self.animate
+        self.animate = animate
+        if framesChanged || fpsChanged || animateChanged {
+            restartTimer()
         }
     }
 
-    @ViewBuilder private func frameImage(at t: Double) -> some View {
-        if frames.isEmpty {
-            Image(systemName: "pawprint.fill").font(.system(size: 36))
-        } else {
-            let index = Int(t * fps) % frames.count
-            Image(nsImage: frames[index])
-                .resizable()
-                .interpolation(.high)
-                .scaledToFit()
-                .frame(width: size, height: size)
+    private func restartTimer() {
+        timer?.invalidate()
+        timer = nil
+        // When animations are disabled, show frame 0 and start no timer.
+        guard animate && cgFrames.count > 1 && fps > 0 else {
+            showCurrent()
+            return
         }
+        showCurrent()
+        // The Timer block is @Sendable, so it captures nothing; hop to the main
+        // actor (where this NSView lives) to advance the frame.
+        let t = Timer(timeInterval: 1.0 / fps, repeats: true) { _ in
+            Task { @MainActor [weak self] in self?.advance() }
+        }
+        // .common so the pet keeps animating during menu/scroll tracking.
+        RunLoop.main.add(t, forMode: .common)
+        timer = t
     }
 
-    private var fps: Double {
-        switch mood {
-        case .working, .celebrate: return 8
-        case .waiting: return 4
-        default: return 3
-        }
+    private func advance() {
+        guard !cgFrames.isEmpty else { return }
+        index = (index + 1) % cgFrames.count
+        showCurrent()
+    }
+
+    private func showCurrent() {
+        guard !cgFrames.isEmpty else { layer?.contents = nil; return }
+        layer?.contents = cgFrames[index % cgFrames.count]
+    }
+
+    override func viewDidChangeBackingProperties() {
+        super.viewDidChangeBackingProperties()
+        layer?.contentsScale = window?.backingScaleFactor ?? 2
+    }
+
+    /// Stops the frame timer. Called from `SpriteLayer.dismantleNSView` when the
+    /// SwiftUI view is removed (Swift 6 forbids touching the non-Sendable timer
+    /// from a nonisolated `deinit`).
+    func teardown() {
+        timer?.invalidate()
+        timer = nil
     }
 }

--- a/Sources/App/OnboardingView.swift
+++ b/Sources/App/OnboardingView.swift
@@ -73,7 +73,8 @@ struct OnboardingView: View {
                     RoundedRectangle(cornerRadius: 16).fill(.white.opacity(0.05))
                         .overlay(RoundedRectangle(cornerRadius: 16).strokeBorder(Color.systemAccent.opacity(0.3)))
                     if let pack = selectedPack {
-                        ImageSpriteView(frames: pack.clip(0), mood: .idle, size: 90)
+                        ImageSpriteView(frames: pack.clip(0), mood: .idle,
+                                        fps: pet.spriteFPS(forMood: .idle), size: 90)
                     } else {
                         Image(systemName: "pawprint.fill").font(.system(size: 40)).foregroundStyle(.white.opacity(0.3))
                     }

--- a/Sources/App/PetBindings.swift
+++ b/Sources/App/PetBindings.swift
@@ -11,7 +11,7 @@ struct PetBindings: Equatable {
 
     /// Spreads the first clips across states, clamped to what the pack has.
     static func defaults(clipCount: Int) -> PetBindings {
-        let order: [PetMood] = [.idle, .working, .waiting, .done, .celebrate]
+        let order: [PetMood] = [.idle, .working, .waiting, .done, .celebrate, .sleepy, .levelup]
         var map: [String: Int] = [:]
         for (i, mood) in order.enumerated() {
             map[mood.rawValue] = clipCount > 0 ? min(i, clipCount - 1) : 0

--- a/Sources/App/PetCareController.swift
+++ b/Sources/App/PetCareController.swift
@@ -61,27 +61,36 @@ final class PetCareController: ObservableObject {
         }
     }
 
-    // MARK: - Feeding (always the selected pet)
+    // MARK: - Feeding
 
     /// A finished agent session — the pet's proper meal.
-    func recordMeal() {
-        mutateCurrent { PetCare.recordMeal(state: &$0, now: Date()) }
+    /// Pass `petID` to feed a specific pet (Split ON); `nil` feeds the selected pet (back-compat).
+    func recordMeal(petID: String? = nil) {
+        mutate(petID: petID) { PetCare.recordMeal(state: &$0, now: Date()) }
     }
 
     /// Tokens consumed by a Claude turn (transcript usage delta).
-    func feedTokens(_ tokens: Int) {
+    /// Pass `petID` to feed a specific pet (Split ON); `nil` feeds the selected pet (back-compat).
+    func feedTokens(_ tokens: Int, petID: String? = nil) {
         guard tokens > 0 else { return }
-        mutateCurrent { PetCare.feedTokens(tokens, state: &$0, now: Date()) }
+        mutate(petID: petID) { PetCare.feedTokens(tokens, state: &$0, now: Date()) }
     }
 
     /// Rolls the daily counters over; UI refresh timers call this so "today"
     /// numbers reset at midnight even with no feeding events.
     func refreshDay() {
-        mutateCurrent { PetCare.rollover(&$0, now: Date()) }
+        mutate(petID: nil) { PetCare.rollover(&$0, now: Date()) }
     }
 
-    private func mutateCurrent(_ change: (inout PetCareState) -> Void) {
-        guard let petID = currentPetID else { return }
+    /// Resolves which pet receives a feed: `requested` if it is an installed
+    /// pack, otherwise falls back to `selectedPetID`.
+    private func resolvedFeedTarget(_ requested: String?) -> String? {
+        if let id = requested, ImagePetStore.shared.pack(id: id) != nil { return id }
+        return currentPetID
+    }
+
+    private func mutate(petID requested: String?, _ change: (inout PetCareState) -> Void) {
+        guard let petID = resolvedFeedTarget(requested) else { return }
         let levelBefore = PetCare.level(forXP: state(for: petID).xp)
         var s = state(for: petID)
         change(&s)

--- a/Sources/App/PetCareController.swift
+++ b/Sources/App/PetCareController.swift
@@ -104,7 +104,7 @@ final class PetCareController: ObservableObject {
                 format: NSLocalizedString("Level up! Lv %d ⭐", comment: "pet level-up celebrate line"),
                 levelAfter
             )
-            PetController.shared.flashCelebrate(line: line)
+            PetController.shared.flashLevelUp(line: line)
         }
     }
 

--- a/Sources/App/PetController.swift
+++ b/Sources/App/PetController.swift
@@ -86,9 +86,9 @@ final class PetController: ObservableObject {
     }
 
     /// Returns the effective sprite fps for a given mood, honouring the slider.
-    /// Idle is capped at 2 fps regardless of the slider value (idle CPU win).
+    /// Idle and sleepy are capped at 2 fps regardless of the slider value (calm CPU win).
     func spriteFPS(forMood mood: PetMood) -> Double {
-        mood == .idle ? min(animationFPS, 2) : animationFPS
+        (mood == .idle || mood == .sleepy) ? min(animationFPS, 2) : animationFPS
     }
 
     private var sizeAnimTimer: Timer?
@@ -137,9 +137,9 @@ final class PetController: ObservableObject {
             syncWindows()
             return
         }
-        if mood == .celebrate {
+        if mood == .celebrate || mood == .levelup {
             syncWindows()
-            return  // let the 3-second celebration finish regardless of new state
+            return  // let the 3-second celebrate / level-up burst finish regardless of new state
         }
         celebrateTimer?.invalidate()
         setMood(resolved)
@@ -177,14 +177,15 @@ final class PetController: ObservableObject {
         syncWindows()
     }
 
-    /// Plays a short celebrate burst with a custom line (e.g. a level-up),
-    /// then settles back to the aggregate mood. Sets `chatLine` directly —
-    /// `setMood` would re-roll it from the message pools.
-    func flashCelebrate(line: String) {
+    /// Plays a short level-up burst with a custom line, using the dedicated
+    /// `.levelup` mood (a distinct clip from the done-celebrate), then settles
+    /// back to the aggregate mood. Sets `chatLine` directly — `setMood` would
+    /// re-roll it from the message pools.
+    func flashLevelUp(line: String) {
         celebrateTimer?.invalidate()
         chatLineCount = 0
         activeAgentSessions = []
-        mood = .celebrate
+        mood = .levelup
         chatLine = line
         StatusBarController.shared.refreshTitle()
         celebrateTimer = Timer.scheduledTimer(withTimeInterval: Self.celebrateDuration, repeats: false) { _ in
@@ -267,7 +268,7 @@ final class PetController: ObservableObject {
     /// bubble isn't double-drawn); otherwise a per-mood pool pick.
     private func chatLine(forMood mood: PetMood, sessions: [AgentSession]) -> String {
         switch mood {
-        case .idle:
+        case .idle, .sleepy:
             guard showIdleMessage else { return "" }
             return idleLine()
         case .working, .waiting:
@@ -275,7 +276,7 @@ final class PetController: ObservableObject {
                 return sessions.map { "• \(TickerFormatter.line(for: $0))" }.joined(separator: "\n")
             }
             return chatLine(forMood: mood)
-        case .done, .celebrate:
+        case .done, .celebrate, .levelup:
             return chatLine(forMood: mood)
         }
     }
@@ -456,16 +457,16 @@ final class PetController: ObservableObject {
 
         // A break nudge overrides the home/default pet (rest visual + line) in
         // both split modes. Project pets keep their own mood — this nudges the
-        // user, not the agents. `.idle` is the rest visual until feature 2 adds
-        // a dedicated `sleepy` clip.
+        // user, not the agents. `.sleepy` is the rest visual; `.idle` on perk-up.
         if spec.key == PetWindowPlanner.defaultKey, let bs = breakState {
+            let mood: PetMood
             let line: String
             switch bs {
-            case .resting(let l): line = l
-            case .perkUp(let l): line = l
+            case .resting(let l): mood = .sleepy; line = l
+            case .perkUp(let l): mood = .idle; line = l
             }
             return PetWindowController.WindowState(
-                petID: petID, mood: .idle, sessions: [], count: 0, chatLine: line)
+                petID: petID, mood: mood, sessions: [], count: 0, chatLine: line)
         }
 
         // In single-window mode (splitPet OFF) the default spec IS the global

--- a/Sources/App/PetController.swift
+++ b/Sources/App/PetController.swift
@@ -33,6 +33,22 @@ final class PetController: ObservableObject {
             update(sessions: latestSessions)   // re-evaluate windows when toggled
         }
     }
+    /// When disabled, freezes all continuous/perpetual pet and bubble animation so
+    /// the SwiftUI render loop can go idle (lower CPU, reduce-motion option).
+    @Published var animationsEnabled: Bool =
+        (UserDefaults.standard.object(forKey: "agentpet.animationsEnabled") as? Bool) ?? true {
+        didSet { UserDefaults.standard.set(animationsEnabled, forKey: "agentpet.animationsEnabled") }
+    }
+    /// User-adjustable sprite frame rate (1–12 fps). Active moods animate at this
+    /// rate; idle is capped at 2 fps regardless of the slider (idle CPU win).
+    @Published var animationFPS: Double =
+        ((UserDefaults.standard.object(forKey: "agentpet.animationFPS") as? Double) ?? 8).clampedFPS {
+        didSet {
+            let v = animationFPS.clampedFPS
+            if v != animationFPS { animationFPS = v; return }   // re-entrancy guard for clamp
+            UserDefaults.standard.set(animationFPS, forKey: "agentpet.animationFPS")
+        }
+    }
     /// Sprite point size, freely adjustable via a slider.
     @Published var petPoint: Double {
         didSet { UserDefaults.standard.set(petPoint, forKey: Self.sizeKey) }
@@ -67,6 +83,12 @@ final class PetController: ObservableObject {
 
     func start() {
         // Ticker drives chatLine updates; no separate chat timer needed.
+    }
+
+    /// Returns the effective sprite fps for a given mood, honouring the slider.
+    /// Idle is capped at 2 fps regardless of the slider value (idle CPU win).
+    func spriteFPS(forMood mood: PetMood) -> Double {
+        mood == .idle ? min(animationFPS, 2) : animationFPS
     }
 
     private var sizeAnimTimer: Timer?
@@ -424,6 +446,13 @@ final class PetController: ObservableObject {
             chatLine: chatLine(forMood: spec.mood, sessions: groupSessions)
         )
     }
+}
+
+// MARK: - FPS helpers
+
+private extension Double {
+    /// Clamps a frame-rate value to the valid 1–12 fps slider range.
+    var clampedFPS: Double { min(max(self, 1), 12) }
 }
 
 /// Built-in (system) chat lines per mood.

--- a/Sources/App/PetController.swift
+++ b/Sources/App/PetController.swift
@@ -359,6 +359,48 @@ final class PetController: ObservableObject {
     /// Keys currently in a celebrate burst, with the line to display.
     private var celebratingKeys: [String: String] = [:]
 
+    // MARK: - Break reminder (home pet rests)
+
+    /// Transient override shown on the home/default pet during a break.
+    private enum BreakDisplay {
+        case resting(line: String)
+        case perkUp(line: String)
+    }
+    private var breakState: BreakDisplay?
+    private var breakPerkTimer: Timer?
+
+    /// Puts the home/default pet into a resting state until `endBreakRest`.
+    /// Only the `default` window is affected; project pets keep their mood.
+    func beginBreakRest(line: String) {
+        breakPerkTimer?.invalidate()
+        breakState = .resting(line: line)
+        syncWindows()
+    }
+
+    /// Clears any in-progress break rest immediately (e.g. the user disabled the
+    /// reminder mid-break). Without this the home pet would stay "resting", since
+    /// only the break-over path clears `breakState`.
+    func cancelBreakRest() {
+        breakPerkTimer?.invalidate()
+        breakPerkTimer = nil
+        guard breakState != nil else { return }
+        breakState = nil
+        syncWindows()
+    }
+
+    /// Wakes the home/default pet: a short "back to work" line, then clears.
+    func endBreakRest(line: String) {
+        breakPerkTimer?.invalidate()
+        breakState = .perkUp(line: line)
+        syncWindows()
+        breakPerkTimer = Timer.scheduledTimer(withTimeInterval: Self.celebrateDuration, repeats: false) { _ in
+            Task { @MainActor [weak self] in
+                self?.breakState = nil
+                self?.syncWindows()
+            }
+        }
+    }
+
     /// Plans the per-project pet windows from the current sessions and reconciles
     /// the window registry. Single-pet mode (Split OFF) yields exactly one
     /// "default" window whose state mirrors today's aggregate behaviour.
@@ -367,7 +409,8 @@ final class PetController: ObservableObject {
             sessions: latestSessions,
             split: splitPet,
             mappings: ProjectPetSettings.shared.mappings,
-            defaultPetID: selectedPetID
+            defaultPetID: selectedPetID,
+            forceDefault: breakState != nil
         )
 
         let liveKeys = Set(specs.map(\.key))
@@ -410,6 +453,20 @@ final class PetController: ObservableObject {
             if let id = spec.petID, ImagePetStore.shared.pack(id: id) != nil { return id }
             return selectedPetID
         }()
+
+        // A break nudge overrides the home/default pet (rest visual + line) in
+        // both split modes. Project pets keep their own mood — this nudges the
+        // user, not the agents. `.idle` is the rest visual until feature 2 adds
+        // a dedicated `sleepy` clip.
+        if spec.key == PetWindowPlanner.defaultKey, let bs = breakState {
+            let line: String
+            switch bs {
+            case .resting(let l): line = l
+            case .perkUp(let l): line = l
+            }
+            return PetWindowController.WindowState(
+                petID: petID, mood: .idle, sessions: [], count: 0, chatLine: line)
+        }
 
         // In single-window mode (splitPet OFF) the default spec IS the global
         // aggregate, so mirror it verbatim — mood includes the transient

--- a/Sources/App/PetController.swift
+++ b/Sources/App/PetController.swift
@@ -26,6 +26,13 @@ final class PetController: ObservableObject {
             refreshChat()
         }
     }
+    /// When enabled, spawns one pet window per active project instead of a single shared pet.
+    @Published var splitPet: Bool = UserDefaults.standard.bool(forKey: "agentpet.splitPet") {
+        didSet {
+            UserDefaults.standard.set(splitPet, forKey: "agentpet.splitPet")
+            update(sessions: latestSessions)   // re-evaluate windows when toggled
+        }
+    }
     /// Sprite point size, freely adjustable via a slider.
     @Published var petPoint: Double {
         didSet { UserDefaults.standard.set(petPoint, forKey: Self.sizeKey) }
@@ -34,18 +41,6 @@ final class PetController: ObservableObject {
     static let minPoint: Double = 60
     static let maxPoint: Double = 240
     static let presets: [(String, Double)] = [("S", 84), ("M", 120), ("L", 168)]
-
-    /// Floating window size. Width is wide enough for agent-ticker lines;
-    /// height grows with the number of lines in the bubble.
-    static func windowSize(forPoint point: Double, lineCount: Int = 1) -> CGSize {
-        let count = max(lineCount, 1)
-        let bubbleH = CGFloat(count) * 22 + 16   // 22pt per line + top/bottom padding
-        return CGSize(
-            width: max(point + 110, 320),         // 320pt fits typical agent lines
-            height: point + bubbleH + 28          // 28pt for triangle + spacing + margin
-        )
-    }
-    var windowSize: CGSize { Self.windowSize(forPoint: petPoint, lineCount: max(chatLineCount, 1)) }
 
     private var lastResolved: PetMood = .idle
     private var latestSessions: [AgentSession] = []
@@ -117,9 +112,11 @@ final class PetController: ObservableObject {
             celebrateTimer = Timer.scheduledTimer(withTimeInterval: Self.celebrateDuration, repeats: false) { _ in
                 Task { @MainActor [weak self] in self?.settleAfterCelebrate() }
             }
+            syncWindows()
             return
         }
         if mood == .celebrate {
+            syncWindows()
             return  // let the 3-second celebration finish regardless of new state
         }
         celebrateTimer?.invalidate()
@@ -137,6 +134,7 @@ final class PetController: ObservableObject {
             chatLineCount = 0
             activeAgentSessions = []
         }
+        syncWindows()
     }
 
     /// Rebuilds chat state when the user toggles multi-agent bubble mode.
@@ -149,10 +147,12 @@ final class PetController: ObservableObject {
             activeAgentSessions = []
             refreshChat()
         }
+        syncWindows()
     }
 
     private func settleAfterCelebrate() {
         setMood(MoodResolver.aggregate(latestSessions))
+        syncWindows()
     }
 
     /// Plays a short celebrate burst with a custom line (e.g. a level-up),
@@ -168,6 +168,7 @@ final class PetController: ObservableObject {
         celebrateTimer = Timer.scheduledTimer(withTimeInterval: Self.celebrateDuration, repeats: false) { _ in
             Task { @MainActor [weak self] in self?.settleAfterCelebrate() }
         }
+        syncWindows()
     }
 
     private func setMood(_ newMood: PetMood) {
@@ -186,21 +187,21 @@ final class PetController: ObservableObject {
         guard showChat else {
             chatLine = ""
             StatusBarController.shared.refreshTitle()
+            syncWindows()
             return
         }
         if mood == .idle {
             guard showIdleMessage else {
                 chatLine = ""
                 StatusBarController.shared.refreshTitle()
+                syncWindows()
                 return
             }
             if reroll || chatLine.isEmpty {
-                let pool = BubbleSettings.shared.multiAgentBubbleEnabled
-                    ? BubbleMessages.shared.lines(for: nil, mood: .idle)
-                    : ChatSettings.shared.lines(for: .idle)
-                chatLine = CareChat.idlePool(base: pool).randomElement() ?? IdleBoost.line()
+                chatLine = idleLine()
             }
             StatusBarController.shared.refreshTitle()
+            syncWindows()
             return
         }
         // Multi-agent mode owns chatLine during working/waiting; otherwise use PetChat.
@@ -208,15 +209,53 @@ final class PetController: ObservableObject {
             && BubbleSettings.shared.multiAgentBubbleEnabled
             && chatLineCount > 0 {
             StatusBarController.shared.refreshTitle()
+            syncWindows()
             return
         }
         if reroll || chatLine.isEmpty {
-            let pool = BubbleSettings.shared.multiAgentBubbleEnabled
-                ? BubbleMessages.shared.lines(for: nil, mood: mood)
-                : ChatSettings.shared.lines(for: mood)
-            chatLine = pool.randomElement() ?? ""
+            chatLine = chatLine(forMood: mood)
         }
         StatusBarController.shared.refreshTitle()
+        syncWindows()
+    }
+
+    // MARK: - Chat line (reusable per-mood line picker)
+
+    /// The idle "doing nothing" chatter, care-coloured (hunger / budget anxiety).
+    /// Shared by the aggregate `refreshChat` and per-project home windows.
+    private func idleLine() -> String {
+        let pool = BubbleSettings.shared.multiAgentBubbleEnabled
+            ? BubbleMessages.shared.lines(for: nil, mood: .idle)
+            : ChatSettings.shared.lines(for: .idle)
+        return CareChat.idlePool(base: pool).randomElement() ?? IdleBoost.line()
+    }
+
+    /// A fresh chat line for a non-idle mood, honouring the bubble source.
+    /// Reused for both the aggregate pet and per-project split windows.
+    private func chatLine(forMood mood: PetMood) -> String {
+        let pool = BubbleSettings.shared.multiAgentBubbleEnabled
+            ? BubbleMessages.shared.lines(for: nil, mood: mood)
+            : ChatSettings.shared.lines(for: mood)
+        return pool.randomElement() ?? ""
+    }
+
+    /// The chat line shown for a planned window. For working/waiting in
+    /// multi-agent mode the structured `AgentBubble` carries the rows, so the
+    /// `chatLine` is only the plain-text fallback (and stays empty so the
+    /// bubble isn't double-drawn); otherwise a per-mood pool pick.
+    private func chatLine(forMood mood: PetMood, sessions: [AgentSession]) -> String {
+        switch mood {
+        case .idle:
+            guard showIdleMessage else { return "" }
+            return idleLine()
+        case .working, .waiting:
+            if BubbleSettings.shared.multiAgentBubbleEnabled && !sessions.isEmpty {
+                return sessions.map { "• \(TickerFormatter.line(for: $0))" }.joined(separator: "\n")
+            }
+            return chatLine(forMood: mood)
+        case .done, .celebrate:
+            return chatLine(forMood: mood)
+        }
     }
 
     // MARK: - Pet tap interaction
@@ -287,6 +326,103 @@ final class PetController: ObservableObject {
             chatLine = active.map { "• \(TickerFormatter.line(for: $0))" }.joined(separator: "\n")
         }
         StatusBarController.shared.refreshTitle()
+        syncWindows()
+    }
+
+    // MARK: - Window coordination (planner → PetWindowController)
+
+    /// Per-window mood from the previous sync, used to fire a celebrate burst
+    /// when a window's group transitions into `.done`.
+    private var lastMoodByKey: [String: PetMood] = [:]
+    /// Keys currently in a celebrate burst, with the line to display.
+    private var celebratingKeys: [String: String] = [:]
+
+    /// Plans the per-project pet windows from the current sessions and reconciles
+    /// the window registry. Single-pet mode (Split OFF) yields exactly one
+    /// "default" window whose state mirrors today's aggregate behaviour.
+    private func syncWindows() {
+        let specs = PetWindowPlanner.plan(
+            sessions: latestSessions,
+            split: splitPet,
+            mappings: ProjectPetSettings.shared.mappings,
+            defaultPetID: selectedPetID
+        )
+
+        let liveKeys = Set(specs.map(\.key))
+        // Drop tracking for windows that no longer exist.
+        lastMoodByKey = lastMoodByKey.filter { liveKeys.contains($0.key) }
+        celebratingKeys = celebratingKeys.filter { liveKeys.contains($0.key) }
+
+        // Fire a celebrate burst when a window's group newly enters `.done`.
+        // In Split-ON mode the defaultKey window is a real project-less group and
+        // must also get per-key celebrate; in Split-OFF the defaultKey celebrates
+        // via the global mood mirror, so we exclude it here to avoid doubling.
+        for spec in specs where spec.key != PetWindowPlanner.defaultKey || splitPet {
+            let prev = lastMoodByKey[spec.key]
+            if spec.mood == .done && prev != nil && prev != .done {
+                let line = chatLine(forMood: .celebrate)
+                celebratingKeys[spec.key] = line
+                let key = spec.key
+                Timer.scheduledTimer(withTimeInterval: Self.celebrateDuration, repeats: false) { _ in
+                    Task { @MainActor [weak self] in
+                        self?.celebratingKeys.removeValue(forKey: key)
+                        self?.syncWindows()
+                    }
+                }
+            }
+            lastMoodByKey[spec.key] = spec.mood
+        }
+
+        PetWindowController.shared.sync(specs: specs) { [weak self] spec in
+            self?.windowState(for: spec)
+                ?? PetWindowController.WindowState(petID: spec.petID, mood: spec.mood,
+                                                   sessions: [], count: spec.count, chatLine: "")
+        }
+    }
+
+    /// Resolves the displayed state for one planned window.
+    private func windowState(for spec: PetWindowSpec) -> PetWindowController.WindowState {
+        // Substitute the selected pet when the configured pet was deleted, so a
+        // missing sprite falls back to the default instead of the paw placeholder.
+        let petID: String? = {
+            if let id = spec.petID, ImagePetStore.shared.pack(id: id) != nil { return id }
+            return selectedPetID
+        }()
+
+        // In single-window mode (splitPet OFF) the default spec IS the global
+        // aggregate, so mirror it verbatim — mood includes the transient
+        // celebrate burst, sessions and chatLine are already computed globally.
+        // With splitPet ON the planner emits a real spec for the project-less
+        // group; fall through so it resolves from that spec like any other key.
+        if spec.key == PetWindowPlanner.defaultKey && !splitPet {
+            return PetWindowController.WindowState(
+                petID: petID,
+                mood: mood,
+                sessions: activeAgentSessions,
+                count: chatLineCount,
+                chatLine: chatLine
+            )
+        }
+
+        // A per-project window in a celebrate burst overrides its mood + line.
+        if let line = celebratingKeys[spec.key] {
+            return PetWindowController.WindowState(
+                petID: petID, mood: .celebrate, sessions: [], count: spec.count, chatLine: line
+            )
+        }
+
+        // Resolve full sessions for this group's bubble (sorted like the ticker).
+        let ids = Set(spec.sessionIDs)
+        let groupSessions = TickerFormatter.sorted(
+            latestSessions.filter { ids.contains($0.id) && $0.state != .idle && $0.state != .registered }
+        )
+        return PetWindowController.WindowState(
+            petID: petID,
+            mood: spec.mood,
+            sessions: groupSessions,
+            count: spec.count,
+            chatLine: chatLine(forMood: spec.mood, sessions: groupSessions)
+        )
     }
 }
 

--- a/Sources/App/PetStatsView.swift
+++ b/Sources/App/PetStatsView.swift
@@ -5,6 +5,9 @@ import AgentPetCore
 /// The pet's right-click HUD: the companion's stats plus a compact footer with
 /// Settings / Updates / Quit (the same actions as the menu bar popover).
 struct PetStatsView: View {
+    /// The pet whose stats to show. `nil` resolves to the globally selected pet
+    /// (preserves today's right-click-on-the-single-pet behaviour).
+    var petID: String? = nil
     @ObservedObject private var care = PetCareController.shared
     @ObservedObject private var pet = PetController.shared
     @ObservedObject private var imagePets = ImagePetStore.shared
@@ -14,14 +17,25 @@ struct PetStatsView: View {
 
     private static let stageColors: [Color] = [.green, .teal, .blue, .purple, .orange]
 
+    /// The pet id this card is showing — the passed id, else the selected pet.
+    private var resolvedPetID: String? { petID ?? pet.selectedPetID }
+
     private var pack: ImagePetPack? {
-        pet.selectedPetID.flatMap { imagePets.pack(id: $0) }
+        resolvedPetID.flatMap { imagePets.pack(id: $0) }
     }
 
-    private var stageColor: Color { Self.stageColors[min(care.stageIndex, Self.stageColors.count - 1)] }
+    /// Care state of the resolved pet.
+    private var careState: PetCareState { care.state(for: resolvedPetID) }
+    private var level: Int { PetCare.displayLevel(forXP: careState.xp) }
+    private var stageKey: String { PetCare.stageName(forLevel: PetCare.level(forXP: careState.xp)) }
+    private var stageIndex: Int { PetCare.stageIndex(forLevel: PetCare.level(forXP: careState.xp)) }
+    private var levelProgress: Double { PetCare.progress(forXP: careState.xp) }
+    private var hunger: PetHunger { PetCare.hunger(state: careState, now: Date()) }
+
+    private var stageColor: Color { Self.stageColors[min(stageIndex, Self.stageColors.count - 1)] }
 
     var body: some View {
-        let state = care.current
+        let state = careState
         VStack(alignment: .leading, spacing: 12) {
             header(state)
             xpBlock(state)
@@ -106,10 +120,10 @@ struct PetStatsView: View {
                 Text(pack?.displayName ?? NSLocalizedString("Your pet", comment: ""))
                     .font(.system(size: 14, weight: .bold)).foregroundStyle(.white)
                 HStack(spacing: 6) {
-                    Text(verbatim: "Lv \(care.level)")
+                    Text(verbatim: "Lv \(level)")
                         .font(.system(size: 12, weight: .bold)).foregroundStyle(stageColor)
-                    StageBadge(stageIndex: care.stageIndex, size: 16)
-                    Text(NSLocalizedString(care.stageKey, comment: "stage"))
+                    StageBadge(stageIndex: stageIndex, size: 16)
+                    Text(NSLocalizedString(stageKey, comment: "stage"))
                         .font(.system(size: 10, weight: .semibold))
                         .padding(.horizontal, 6).padding(.vertical, 2)
                         .background(Capsule().fill(stageColor.opacity(0.2)))
@@ -133,16 +147,16 @@ struct PetStatsView: View {
     private func xpBlock(_ state: PetCareState) -> some View {
         let (inLevel, span) = PetCare.xpWithinLevel(forXP: state.xp)
         return VStack(alignment: .leading, spacing: 4) {
-            ProgressView(value: care.levelProgress).tint(stageColor).controlSize(.small)
+            ProgressView(value: levelProgress).tint(stageColor).controlSize(.small)
             HStack {
                 Text(verbatim: "\(Self.plain(inLevel)) / \(Self.plain(span)) XP")
                     .font(.system(size: 10)).foregroundStyle(.white.opacity(0.45))
                 Spacer()
-                Text(verbatim: "\(Int((care.levelProgress * 100).rounded()))%")
+                Text(verbatim: "\(Int((levelProgress * 100).rounded()))%")
                     .font(.system(size: 10, weight: .semibold)).foregroundStyle(stageColor)
             }
             Text(String(format: NSLocalizedString("≈ %@ tokens to Lv %d", comment: ""),
-                        Self.tokenString(PetCare.tokensToNextLevel(state: state)), care.level + 1))
+                        Self.tokenString(PetCare.tokensToNextLevel(state: state)), level + 1))
                 .font(.system(size: 10, weight: .medium)).foregroundStyle(stageColor.opacity(0.9))
         }
     }
@@ -265,7 +279,7 @@ struct PetStatsView: View {
 
     /// Continuous fullness 0…1 (48h since the last feeding → empty).
     private var fullness: Double {
-        guard let last = care.current.lastFedAt else { return 0.5 }
+        guard let last = careState.lastFedAt else { return 0.5 }
         let hours = Date().timeIntervalSince(last) / 3600
         return max(0, min(1, 1 - hours / 48))
     }
@@ -281,7 +295,7 @@ struct PetStatsView: View {
     }
 
     private var hungerText: String {
-        switch care.hunger {
+        switch hunger {
         case .full: return NSLocalizedString("Full", comment: "hunger")
         case .satisfied: return NSLocalizedString("Satisfied", comment: "hunger")
         case .peckish: return NSLocalizedString("Peckish", comment: "hunger")

--- a/Sources/App/PetView.swift
+++ b/Sources/App/PetView.swift
@@ -8,10 +8,11 @@ private let TYPE_INTERVAL: TimeInterval = 0.045
 private let DOT_CYCLE_INTERVAL: TimeInterval = 0.400
 
 /// The pet sprite alone (imported pack, reacting to mood). Shows a paw
-/// placeholder if no pet is selected yet.
+/// placeholder if no pet is selected yet. The pet id and mood come from the
+/// per-window model rather than the global `PetController`.
 struct PetView: View {
+    @ObservedObject var model: PetWindowModel
     var size: CGFloat = 120
-    @ObservedObject private var pet = PetController.shared
     @ObservedObject private var imagePets = ImagePetStore.shared
     @ObservedObject private var bindings = PetBindingsStore.shared
 
@@ -22,9 +23,9 @@ struct PetView: View {
     }
 
     @ViewBuilder private var content: some View {
-        if let id = pet.selectedPetID, let pack = imagePets.pack(id: id) {
-            let clip = bindings.clipIndex(packId: pack.id, clipCount: pack.clipCount, mood: pet.mood)
-            ImageSpriteView(frames: pack.clip(clip), mood: pet.mood, size: size)
+        if let id = model.petID, let pack = imagePets.pack(id: id) {
+            let clip = bindings.clipIndex(packId: pack.id, clipCount: pack.clipCount, mood: model.mood)
+            ImageSpriteView(frames: pack.clip(clip), mood: model.mood, size: size)
         } else {
             Image(systemName: "pawprint.fill")
                 .font(.system(size: size * 0.4))
@@ -42,26 +43,30 @@ private struct PetContentSizeKey: PreferenceKey {
     }
 }
 
-/// The full floating window content: a chat bubble above the pet.
+/// The full floating window content: a chat bubble above the pet. Per-window
+/// fields (mood/petID/sessions/chatLine) come from `model`; global toggles and
+/// the tap-interaction state still come from `PetController.shared`.
 struct FloatingPetView: View {
+    @ObservedObject var model: PetWindowModel
     @ObservedObject private var pet = PetController.shared
     @ObservedObject private var bubbleSettings = BubbleSettings.shared
     @ObservedObject private var appLang = AppLanguage.shared
 
     var body: some View {
         VStack(spacing: 2) {
-            if pet.showChat && pet.selectedPetID != nil {
-                if bubbleSettings.multiAgentBubbleEnabled && !pet.activeAgentSessions.isEmpty {
-                    AgentBubble(sessions: pet.activeAgentSessions)
+            if pet.showChat && model.petID != nil {
+                if bubbleSettings.multiAgentBubbleEnabled && !model.sessions.isEmpty {
+                    AgentBubble(sessions: model.sessions, forceProjectToken: model.projectName != nil)
                         .padding(.horizontal, 10).padding(.vertical, 6)
                         .transition(AnyTransition.scale(scale: 0.6).combined(with: .opacity))
-                } else if !pet.chatLine.isEmpty {
-                    ChatBubble(text: pet.chatLine)
+                } else if !model.chatLine.isEmpty {
+                    ChatBubble(text: model.chatLine,
+                               projectName: pet.splitPet ? model.projectName : nil)
                         .padding(.horizontal, 10).padding(.vertical, 6)
                         .transition(AnyTransition.scale(scale: 0.6).combined(with: .opacity))
                 }
             }
-            PetView(size: pet.petPoint)
+            PetView(model: model, size: pet.petPoint)
                 .overlay {
                     if pet.petTapCount > 0 {
                         PetHearts(size: pet.petPoint)
@@ -108,11 +113,11 @@ struct FloatingPetView: View {
                 Color.clear.preference(key: PetContentSizeKey.self, value: proxy.size)
             }
         )
-        .onPreferenceChange(PetContentSizeKey.self) { size in
-            PetWindowController.shared.resizeToContent(size)
+        .onPreferenceChange(PetContentSizeKey.self) { [key = model.key] size in
+            PetWindowController.shared.resizeToContent(size, forKey: key)
         }
-        .animation(.easeInOut(duration: 0.22), value: pet.chatLine)
-        .animation(.spring(response: 0.35, dampingFraction: 0.7), value: pet.activeAgentSessions.count)
+        .animation(.easeInOut(duration: 0.22), value: model.chatLine)
+        .animation(.spring(response: 0.35, dampingFraction: 0.7), value: model.sessions.count)
         .animation(.easeInOut, value: pet.showChat)
         // Re-resolve bubble text when the app language changes at runtime.
         .environment(\.locale, appLang.locale)
@@ -131,9 +136,13 @@ private struct GroupedSession: Identifiable {
 /// Speech bubble listing one row per (agentKind, project) group.
 /// Applies filter/sort/cap from `BubbleSettings` before rendering.
 /// `tailEdge` controls whether the pointer arrow points down (pet) or up (menu bar).
+/// `forceProjectToken`: when true the `.project` token is shown even if the user
+/// hid it in BubbleSettings — used in split-pet windows so duplicate pets are
+/// distinguishable by their project name.
 struct AgentBubble: View {
     let sessions: [AgentSession]
     var tailEdge: Edge = .bottom
+    var forceProjectToken: Bool = false
     @ObservedObject private var settings = BubbleSettings.shared
 
     // attentionPriority is internal to AgentPetCore — use local rank
@@ -267,16 +276,19 @@ struct AgentBubble: View {
         switch settings.displayMode {
         case .list:
             ForEach(groupedSessions) { group in
-                AgentRow(session: group.session, count: group.count, chatStyle: isPetChat)
+                AgentRow(session: group.session, count: group.count, chatStyle: isPetChat,
+                         forceProjectToken: forceProjectToken)
             }
         case .carousel:
-            BubbleCarousel(groups: groupedSessions, chatStyle: isPetChat)
+            BubbleCarousel(groups: groupedSessions, chatStyle: isPetChat,
+                           forceProjectToken: forceProjectToken)
         case .compact:
             BubbleCompactLayout(
                 groups: groupedSessions,
                 totalCount: totalSessionCount,
                 chatStyle: isPetChat,
-                textColor: textColor
+                textColor: textColor,
+                forceProjectToken: forceProjectToken
             )
         }
     }
@@ -295,6 +307,7 @@ struct AgentBubble: View {
 private struct BubbleCarousel: View {
     let groups: [GroupedSession]
     var chatStyle: Bool = false
+    var forceProjectToken: Bool = false
     @ObservedObject private var settings = BubbleSettings.shared
     @State private var index = 0
     @State private var timer: Timer?
@@ -307,7 +320,8 @@ private struct BubbleCarousel: View {
         VStack(alignment: .leading, spacing: chatStyle ? 4 : 5) {
             Group {
                 if let group = groups[safe: index] {
-                    AgentRow(session: group.session, count: group.count, chatStyle: chatStyle)
+                    AgentRow(session: group.session, count: group.count, chatStyle: chatStyle,
+                             forceProjectToken: forceProjectToken)
                         .id(group.id)
                         .transition(.opacity)
                 }
@@ -463,6 +477,7 @@ private struct BubbleCompactLayout: View {
     let totalCount: Int
     var chatStyle: Bool = false
     let textColor: (Double) -> Color
+    var forceProjectToken: Bool = false
     @ObservedObject private var settings = BubbleSettings.shared
     @State private var expanded = false
 
@@ -475,7 +490,8 @@ private struct BubbleCompactLayout: View {
                 .foregroundStyle(textColor(0.45))
 
             ForEach(visibleGroups) { group in
-                AgentRow(session: group.session, count: group.count, chatStyle: chatStyle)
+                AgentRow(session: group.session, count: group.count, chatStyle: chatStyle,
+                         forceProjectToken: forceProjectToken)
             }
 
             if hiddenCount > 0 {
@@ -713,10 +729,13 @@ private struct ShimmeringText: View {
 
 /// One row per agent session. Iterates `BubbleSettings.effectiveLayout` tokens
 /// in order on a single line; project/title shrink before the message does.
+/// `forceProjectToken`: when true the `.project` token is always included even if
+/// the user hid it — used in split-pet windows for project disambiguation.
 private struct AgentRow: View {
     let session: AgentSession
     var count: Int = 1
     var chatStyle: Bool = false
+    var forceProjectToken: Bool = false
     @ObservedObject private var settings = BubbleSettings.shared
     @ObservedObject private var bubbleMsgs = BubbleMessages.shared
 
@@ -734,7 +753,11 @@ private struct AgentRow: View {
     private static let waitingColor = Color(red: 0xF5 / 255.0, green: 0x9E / 255.0, blue: 0x0B / 255.0)
 
     var body: some View {
-        let visible = settings.effectiveLayout.tokens.filter { $0.isVisible && tokenHasValue($0.token) }
+        // In split-pet windows we force the `.project` token visible so the user
+        // can tell apart pets from different projects even if they hid it globally.
+        let visible = settings.effectiveLayout.tokens.filter {
+            ($0.isVisible || (forceProjectToken && $0.token == .project)) && tokenHasValue($0.token)
+        }
 
         HStack(alignment: .center, spacing: 4) {
             if visible.contains(where: { $0.token == .dot }) {
@@ -912,8 +935,11 @@ private struct AgentRow: View {
 
 /// A plain speech bubble with a downward tail, used for celebrate/done lines.
 /// Theme-aware (light/dark/system); reused by the Settings live preview.
+/// When `projectName` is non-nil (split-pet mode), a small dimmed caption is
+/// rendered above the main text so the window is identifiable.
 struct ChatBubble: View {
     let text: String
+    var projectName: String? = nil
     @ObservedObject private var settings = BubbleSettings.shared
 
     private var fill: Color {
@@ -932,6 +958,14 @@ struct ChatBubble: View {
         }
     }
 
+    private var dimmedTextColor: Color {
+        switch settings.theme {
+        case .light:  return .black.opacity(0.45)
+        case .dark:   return .white.opacity(0.45)
+        case .system: return Color.primary.opacity(0.45)
+        }
+    }
+
     private var borderColor: Color {
         switch settings.theme {
         case .light:  return .black.opacity(0.06)
@@ -942,21 +976,30 @@ struct ChatBubble: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            Text(text)
-                .font(.system(size: settings.fontSize.primaryPt, weight: .medium))
-                .foregroundStyle(textColor)
-                .contentTransition(.opacity)   // cross-fade text changes instead of a hard swap (no flicker)
-                .lineLimit(1)
-                .truncationMode(.tail)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 7)
-                .background(Capsule().fill(fill))
-                .overlay(Capsule().strokeBorder(borderColor, lineWidth: 1))
-                // Flatten to one layer so the shadow traces the capsule's
-                // rounded silhouette instead of its rectangular bounding box
-                // (SwiftUI draws boxy shadows on composed views otherwise).
-                .compositingGroup()
-                .shadow(color: .black.opacity(0.18), radius: 5, y: 2)
+            VStack(spacing: 2) {
+                if let name = projectName {
+                    Text(name)
+                        .font(.system(size: settings.fontSize.secondaryPt, weight: .regular))
+                        .foregroundStyle(dimmedTextColor)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                Text(text)
+                    .font(.system(size: settings.fontSize.primaryPt, weight: .medium))
+                    .foregroundStyle(textColor)
+                    .contentTransition(.opacity)   // cross-fade text changes instead of a hard swap (no flicker)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
+            .background(Capsule().fill(fill))
+            .overlay(Capsule().strokeBorder(borderColor, lineWidth: 1))
+            // Flatten to one layer so the shadow traces the capsule's
+            // rounded silhouette instead of its rectangular bounding box
+            // (SwiftUI draws boxy shadows on composed views otherwise).
+            .compositingGroup()
+            .shadow(color: .black.opacity(0.18), radius: 5, y: 2)
             Triangle()
                 .fill(fill)
                 .frame(width: 12, height: 7)

--- a/Sources/App/PetView.swift
+++ b/Sources/App/PetView.swift
@@ -2,6 +2,16 @@ import AppKit
 import SwiftUI
 import AgentPetCore
 
+// MARK: - Animations environment key
+
+private struct AnimationsEnabledKey: EnvironmentKey { static let defaultValue = true }
+extension EnvironmentValues {
+    var animationsEnabled: Bool {
+        get { self[AnimationsEnabledKey.self] }
+        set { self[AnimationsEnabledKey.self] = newValue }
+    }
+}
+
 /// Timing for `AnimatedStatusText`'s erase/retype/ellipsis-cycle phases.
 private let ERASE_INTERVAL: TimeInterval = 0.080
 private let TYPE_INTERVAL: TimeInterval = 0.045
@@ -15,6 +25,7 @@ struct PetView: View {
     var size: CGFloat = 120
     @ObservedObject private var imagePets = ImagePetStore.shared
     @ObservedObject private var bindings = PetBindingsStore.shared
+    @ObservedObject private var pet = PetController.shared
 
     var body: some View {
         content
@@ -25,7 +36,8 @@ struct PetView: View {
     @ViewBuilder private var content: some View {
         if let id = model.petID, let pack = imagePets.pack(id: id) {
             let clip = bindings.clipIndex(packId: pack.id, clipCount: pack.clipCount, mood: model.mood)
-            ImageSpriteView(frames: pack.clip(clip), mood: model.mood, size: size)
+            ImageSpriteView(frames: pack.clip(clip), mood: model.mood,
+                            fps: pet.spriteFPS(forMood: model.mood), size: size)
         } else {
             Image(systemName: "pawprint.fill")
                 .font(.system(size: size * 0.4))
@@ -56,7 +68,7 @@ struct FloatingPetView: View {
         VStack(spacing: 2) {
             if pet.showChat && model.petID != nil {
                 if bubbleSettings.multiAgentBubbleEnabled && !model.sessions.isEmpty {
-                    AgentBubble(sessions: model.sessions, forceProjectToken: model.projectName != nil)
+                    AgentBubble(sessions: model.sessions)
                         .padding(.horizontal, 10).padding(.vertical, 6)
                         .transition(AnyTransition.scale(scale: 0.6).combined(with: .opacity))
                 } else if !model.chatLine.isEmpty {
@@ -121,6 +133,7 @@ struct FloatingPetView: View {
         .animation(.easeInOut, value: pet.showChat)
         // Re-resolve bubble text when the app language changes at runtime.
         .environment(\.locale, appLang.locale)
+        .environment(\.animationsEnabled, pet.animationsEnabled)
     }
 }
 
@@ -136,13 +149,9 @@ private struct GroupedSession: Identifiable {
 /// Speech bubble listing one row per (agentKind, project) group.
 /// Applies filter/sort/cap from `BubbleSettings` before rendering.
 /// `tailEdge` controls whether the pointer arrow points down (pet) or up (menu bar).
-/// `forceProjectToken`: when true the `.project` token is shown even if the user
-/// hid it in BubbleSettings — used in split-pet windows so duplicate pets are
-/// distinguishable by their project name.
 struct AgentBubble: View {
     let sessions: [AgentSession]
     var tailEdge: Edge = .bottom
-    var forceProjectToken: Bool = false
     @ObservedObject private var settings = BubbleSettings.shared
 
     // attentionPriority is internal to AgentPetCore — use local rank
@@ -276,19 +285,16 @@ struct AgentBubble: View {
         switch settings.displayMode {
         case .list:
             ForEach(groupedSessions) { group in
-                AgentRow(session: group.session, count: group.count, chatStyle: isPetChat,
-                         forceProjectToken: forceProjectToken)
+                AgentRow(session: group.session, count: group.count, chatStyle: isPetChat)
             }
         case .carousel:
-            BubbleCarousel(groups: groupedSessions, chatStyle: isPetChat,
-                           forceProjectToken: forceProjectToken)
+            BubbleCarousel(groups: groupedSessions, chatStyle: isPetChat)
         case .compact:
             BubbleCompactLayout(
                 groups: groupedSessions,
                 totalCount: totalSessionCount,
                 chatStyle: isPetChat,
-                textColor: textColor,
-                forceProjectToken: forceProjectToken
+                textColor: textColor
             )
         }
     }
@@ -307,7 +313,6 @@ struct AgentBubble: View {
 private struct BubbleCarousel: View {
     let groups: [GroupedSession]
     var chatStyle: Bool = false
-    var forceProjectToken: Bool = false
     @ObservedObject private var settings = BubbleSettings.shared
     @State private var index = 0
     @State private var timer: Timer?
@@ -320,8 +325,7 @@ private struct BubbleCarousel: View {
         VStack(alignment: .leading, spacing: chatStyle ? 4 : 5) {
             Group {
                 if let group = groups[safe: index] {
-                    AgentRow(session: group.session, count: group.count, chatStyle: chatStyle,
-                             forceProjectToken: forceProjectToken)
+                    AgentRow(session: group.session, count: group.count, chatStyle: chatStyle)
                         .id(group.id)
                         .transition(.opacity)
                 }
@@ -477,7 +481,6 @@ private struct BubbleCompactLayout: View {
     let totalCount: Int
     var chatStyle: Bool = false
     let textColor: (Double) -> Color
-    var forceProjectToken: Bool = false
     @ObservedObject private var settings = BubbleSettings.shared
     @State private var expanded = false
 
@@ -490,8 +493,7 @@ private struct BubbleCompactLayout: View {
                 .foregroundStyle(textColor(0.45))
 
             ForEach(visibleGroups) { group in
-                AgentRow(session: group.session, count: group.count, chatStyle: chatStyle,
-                         forceProjectToken: forceProjectToken)
+                AgentRow(session: group.session, count: group.count, chatStyle: chatStyle)
             }
 
             if hiddenCount > 0 {
@@ -601,7 +603,7 @@ private struct AnimatedStatusText: View {
                     .foregroundStyle(color)
             }
         } else if isStable {
-            ShimmeringText(text: displayed, font: font, color: color)
+            Text(displayed).font(font).foregroundStyle(color)
         } else {
             Text(displayed)
                 .font(font)
@@ -690,54 +692,16 @@ private struct AnimatedStatusText: View {
     }
 }
 
-/// Bright band sweeping left-to-right over text via gradient mask, repeating
-/// every 2.5s. Pure SwiftUI animation — no timers — mirrors a CSS
-/// `background-clip: text` shimmer.
-private struct ShimmeringText: View {
-    let text: String
-    let font: Font
-    let color: Color
-
-    @State private var sweep = false
-
-    var body: some View {
-        let label = Text(text).font(font)
-        ZStack {
-            label.foregroundStyle(color.opacity(0.55))
-            label
-                .foregroundStyle(color)
-                .mask(
-                    GeometryReader { proxy in
-                        let w = proxy.size.width
-                        LinearGradient(
-                            colors: [.clear, .white, .clear],
-                            startPoint: .leading,
-                            endPoint: .trailing
-                        )
-                        .frame(width: w * 0.5)
-                        .offset(x: sweep ? w : -w * 0.5)
-                    }
-                )
-        }
-        .onAppear {
-            withAnimation(.linear(duration: 2.5).repeatForever(autoreverses: false)) {
-                sweep = true
-            }
-        }
-    }
-}
 
 /// One row per agent session. Iterates `BubbleSettings.effectiveLayout` tokens
 /// in order on a single line; project/title shrink before the message does.
-/// `forceProjectToken`: when true the `.project` token is always included even if
-/// the user hid it — used in split-pet windows for project disambiguation.
 private struct AgentRow: View {
     let session: AgentSession
     var count: Int = 1
     var chatStyle: Bool = false
-    var forceProjectToken: Bool = false
     @ObservedObject private var settings = BubbleSettings.shared
     @ObservedObject private var bubbleMsgs = BubbleMessages.shared
+    @Environment(\.animationsEnabled) private var animationsEnabled
 
     private var primaryPt: CGFloat { settings.fontSize.primaryPt }
     private var secondaryPt: CGFloat { settings.fontSize.secondaryPt }
@@ -753,11 +717,7 @@ private struct AgentRow: View {
     private static let waitingColor = Color(red: 0xF5 / 255.0, green: 0x9E / 255.0, blue: 0x0B / 255.0)
 
     var body: some View {
-        // In split-pet windows we force the `.project` token visible so the user
-        // can tell apart pets from different projects even if they hid it globally.
-        let visible = settings.effectiveLayout.tokens.filter {
-            ($0.isVisible || (forceProjectToken && $0.token == .project)) && tokenHasValue($0.token)
-        }
+        let visible = settings.effectiveLayout.tokens.filter { $0.isVisible && tokenHasValue($0.token) }
 
         HStack(alignment: .center, spacing: 4) {
             if visible.contains(where: { $0.token == .dot }) {
@@ -818,9 +778,9 @@ private struct AgentRow: View {
                 message: messageText,
                 font: .system(size: primaryPt, weight: isWaiting ? .semibold : .medium),
                 color: isWaiting ? Self.waitingColor : textColor(0.82),
-                animated: session.state != .done
+                animated: animationsEnabled && session.state != .done
             )
-            .modifier(WaitingTextFlash(active: isWaiting))
+            .modifier(WaitingTextFlash(active: isWaiting && animationsEnabled))
             .lineLimit(1)
             .truncationMode(.tail)
             .layoutPriority(1)
@@ -845,10 +805,17 @@ private struct AgentRow: View {
                     .layoutPriority(-1)
             }
         case .elapsed:
-            // Tick every second so the elapsed time counts up live instead of
-            // freezing at the value sampled when the row was last re-rendered.
-            TimelineView(.periodic(from: .now, by: 1)) { context in
-                Text(elapsedString(since: session.stateSince, now: context.date))
+            if animationsEnabled {
+                // Tick every second so the elapsed time counts up live instead of
+                // freezing at the value sampled when the row was last re-rendered.
+                TimelineView(.periodic(from: .now, by: 1)) { context in
+                    Text(elapsedString(since: session.stateSince, now: context.date))
+                        .font(.system(size: secondaryPt, weight: .regular))
+                        .foregroundStyle(textColor(0.45))
+                        .monospacedDigit()
+                }
+            } else {
+                Text(elapsedString(since: session.stateSince, now: Date()))
                     .font(.system(size: secondaryPt, weight: .regular))
                     .foregroundStyle(textColor(0.45))
                     .monospacedDigit()
@@ -1019,28 +986,26 @@ private struct StateDot: View {
     let color: Color
     let spins: Bool
     let style: BubbleSettings.DotStyle
-
-    private static let frames = ["✶", "✳", "✢", "✻", "✽", "✺"]
-    private static let frameInterval: TimeInterval = 0.15
+    @Environment(\.animationsEnabled) private var animationsEnabled
 
     var body: some View {
         Group {
-            switch style {
-            case .plain:
-                if spins {
-                    BloomingDot(color: color)
-                } else {
+            if !animationsEnabled || !spins {
+                // Static branch — no CALayer, no spin. Plain renders a flat
+                // circle; Claude renders the resting glyph. Identical to the
+                // pre-experiment off/idle path.
+                switch style {
+                case .plain:
                     Circle().fill(color).frame(width: 8, height: 8)
-                }
-            case .claude:
-                if spins {
-                    TimelineView(.periodic(from: .now, by: Self.frameInterval)) { context in
-                        let i = Int(context.date.timeIntervalSinceReferenceDate / Self.frameInterval) % Self.frames.count
-                        glyph(Self.frames[i])
-                    }
-                } else {
+                case .claude:
                     glyph("✻")
                 }
+            } else {
+                // Animated branch (animations on AND spinning) runs entirely in
+                // Core Animation — the ring bloom / glyph cycle live on the
+                // render server and never wake SwiftUI per frame.
+                StateDotLayer(color: color, style: style)
+                    .frame(width: 14, height: 14)
             }
         }
         // The active↔idle/done switch swaps to a wholly different view
@@ -1057,29 +1022,197 @@ private struct StateDot: View {
     }
 }
 
-/// Original plain-dot pulse: glow blooms outward from the dot and fades,
-/// repeating every 1.5s — the box-shadow-style animation for `.plain`.
-private struct BloomingDot: View {
-    let color: Color
-    @State private var blooming = false
+// MARK: - State dot (Core Animation)
 
-    var body: some View {
-        ZStack {
-            Circle()
-                .fill(color)
-                .frame(width: 8, height: 8)
-                .blur(radius: 3)
-                .scaleEffect(blooming ? 2.4 : 1)
-                .opacity(blooming ? 0 : 0.55)
-            Circle()
-                .fill(color)
-                .frame(width: 8, height: 8)
+/// SwiftUI bridge to the CALayer-backed state-dot animator. The bloom pulse
+/// (`.plain`) and the glyph cycle (`.claude`) both run as `CAAnimation`s on the
+/// render server, so — unlike a SwiftUI `TimelineView` — they do NOT force
+/// SwiftUI to re-render the bubble view tree every frame. Only the animated
+/// (animations-on + spinning) path is routed through here; the static paths
+/// stay plain SwiftUI.
+private struct StateDotLayer: NSViewRepresentable {
+    let color: Color
+    let style: BubbleSettings.DotStyle
+
+    func makeNSView(context: Context) -> StateDotNSView {
+        let view = StateDotNSView()
+        view.configure(color: color, style: style)
+        return view
+    }
+
+    func updateNSView(_ view: StateDotNSView, context: Context) {
+        // Called on every SwiftUI re-render of the parent. `configure` is
+        // idempotent: it only rebuilds layers / re-adds CAAnimations when the
+        // color or style actually changed, so an unrelated re-render never
+        // restarts (and visually jitters) the running animation.
+        view.configure(color: color, style: style)
+    }
+
+    static func dismantleNSView(_ view: StateDotNSView, coordinator: ()) {
+        view.teardown()
+    }
+}
+
+/// A layer-backed view that animates the state dot purely in Core Animation.
+/// `.plain` is a static center dot plus an expanding/fading ring; `.claude`
+/// cycles six pre-rendered glyph images via a discrete keyframe animation.
+final class StateDotNSView: NSView {
+    private static let glyphFrames = ["✶", "✳", "✢", "✻", "✽", "✺"]
+    private static let glyphInterval: TimeInterval = 0.15
+
+    private var lastColor: NSColor?
+    private var lastStyle: BubbleSettings.DotStyle?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) not used") }
+
+    /// Idempotent: rebuilds sublayers + re-adds animations only when `color` or
+    /// `style` changed since the last call. SwiftUI re-renders of the parent
+    /// therefore never churn the running CAAnimations.
+    func configure(color: Color, style: BubbleSettings.DotStyle) {
+        let nsColor = NSColor(color)
+        if let lastColor, let lastStyle,
+           lastColor == nsColor, lastStyle == style {
+            return  // nothing relevant changed — leave the animation running.
         }
-        .onAppear {
-            withAnimation(.easeOut(duration: 1.5).repeatForever(autoreverses: false)) {
-                blooming = true
-            }
+        lastColor = nsColor
+        lastStyle = style
+        rebuild(nsColor: nsColor, style: style)
+    }
+
+    private var currentScale: CGFloat { window?.backingScaleFactor ?? 2 }
+
+    private func rebuild(nsColor: NSColor, style: BubbleSettings.DotStyle) {
+        let host = layer ?? CALayer()
+        host.sublayers?.forEach { $0.removeFromSuperlayer() }
+        host.removeAllAnimations()
+        switch style {
+        case .plain:
+            buildPlain(on: host, nsColor: nsColor)
+        case .claude:
+            buildClaude(on: host, nsColor: nsColor)
         }
+    }
+
+    /// Center dot (8×8, static) + an expanding/fading ring (8×8) that scales
+    /// 1→2.4 while fading 0.55→0, repeating forever — the bloom, with no blur
+    /// and no per-frame SwiftUI/CPU cost.
+    private func buildPlain(on host: CALayer, nsColor: NSColor) {
+        let scale = currentScale
+        let dotRect = centeredRect(side: 8)
+
+        let ring = CALayer()
+        ring.frame = dotRect
+        ring.backgroundColor = nsColor.cgColor
+        ring.cornerRadius = 4
+        ring.contentsScale = scale
+        ring.opacity = 0  // resting value once the animation completes
+        host.addSublayer(ring)
+
+        let center = CALayer()
+        center.frame = dotRect
+        center.backgroundColor = nsColor.cgColor
+        center.cornerRadius = 4
+        center.contentsScale = scale
+        host.addSublayer(center)
+
+        let scaleAnim = CABasicAnimation(keyPath: "transform.scale")
+        scaleAnim.fromValue = 1.0
+        scaleAnim.toValue = 2.4
+        let opacityAnim = CABasicAnimation(keyPath: "opacity")
+        opacityAnim.fromValue = 0.55
+        opacityAnim.toValue = 0.0
+
+        let group = CAAnimationGroup()
+        group.animations = [scaleAnim, opacityAnim]
+        group.duration = 1.5
+        group.timingFunction = CAMediaTimingFunction(name: .easeOut)
+        group.repeatCount = .infinity
+        group.isRemovedOnCompletion = false
+        group.fillMode = .forwards
+        ring.add(group, forKey: "bloom")
+    }
+
+    /// A single 14×14 content layer whose `contents` cycles through the six
+    /// pre-rendered glyph images via a discrete keyframe animation.
+    private func buildClaude(on host: CALayer, nsColor: NSColor) {
+        let scale = currentScale
+        let images = Self.glyphFrames.compactMap { glyphImage($0, color: nsColor, scale: scale) }
+
+        let content = CALayer()
+        content.frame = bounds
+        content.contentsGravity = .center
+        content.contentsScale = scale
+        content.contents = images.first
+        host.addSublayer(content)
+
+        guard images.count > 1 else { return }
+        let anim = CAKeyframeAnimation(keyPath: "contents")
+        anim.calculationMode = .discrete
+        anim.values = images
+        anim.duration = Self.glyphInterval * Double(images.count)
+        anim.repeatCount = .infinity
+        anim.isRemovedOnCompletion = false
+        anim.fillMode = .forwards
+        content.add(anim, forKey: "glyphCycle")
+    }
+
+    /// Renders one glyph as a `CGImage` at backing scale.
+    private func glyphImage(_ s: String, color: NSColor, scale: CGFloat) -> CGImage? {
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: NSFont.boldSystemFont(ofSize: 12),
+            .foregroundColor: color,
+        ]
+        let str = NSAttributedString(string: s, attributes: attrs)
+        let glyphSize = str.size()
+        let pointSize = NSSize(width: max(glyphSize.width.rounded(.up), 1),
+                               height: max(glyphSize.height.rounded(.up), 1))
+        let image = NSImage(size: pointSize)
+        image.lockFocus()
+        str.draw(at: .zero)
+        image.unlockFocus()
+        return image.cgImage(forProposedRect: nil, context: nil, hints: nil)
+    }
+
+    private func centeredRect(side: CGFloat) -> CGRect {
+        CGRect(x: (bounds.width - side) / 2,
+               y: (bounds.height - side) / 2,
+               width: side, height: side)
+    }
+
+    override func layout() {
+        super.layout()
+        // Keep sublayer frames centered if the host bounds change. The SwiftUI
+        // `.frame(width:14,height:14)` fixes the size, so this is mostly a
+        // safety net for the initial layout pass.
+        guard let sublayers = layer?.sublayers else { return }
+        if lastStyle == .claude {
+            sublayers.forEach { $0.frame = bounds }
+        } else {
+            let dotRect = centeredRect(side: 8)
+            sublayers.forEach { $0.frame = dotRect }
+        }
+    }
+
+    override func viewDidChangeBackingProperties() {
+        super.viewDidChangeBackingProperties()
+        // Re-render at the new backing scale for crispness on display changes.
+        if let style = lastStyle, let color = lastColor {
+            rebuild(nsColor: color, style: style)
+        }
+    }
+
+    /// Removes the running CAAnimations on teardown. Called from
+    /// `StateDotLayer.dismantleNSView` (Swift 6 forbids touching this from a
+    /// nonisolated `deinit`).
+    func teardown() {
+        layer?.removeAllAnimations()
+        layer?.sublayers?.forEach { $0.removeAllAnimations() }
     }
 }
 

--- a/Sources/App/PetWindowController.swift
+++ b/Sources/App/PetWindowController.swift
@@ -1,9 +1,12 @@
 import AppKit
 import SwiftUI
 import Combine
+import AgentPetCore
 
-/// A borderless, always-on-top, draggable floating window that hosts the pet.
-/// Visibility is user-toggleable; size follows the pet-size setting.
+/// Owns the floating pet panels. A registry keyed by group key ("default" or a
+/// project path): each entry is one borderless, always-on-top, draggable
+/// `NSPanel` hosting a `FloatingPetView(model:)`. Single-pet mode is just N=1
+/// (one "default" window); Split mode spawns one window per active project.
 @MainActor
 final class PetWindowController: ObservableObject {
     static let shared = PetWindowController()
@@ -12,21 +15,163 @@ final class PetWindowController: ObservableObject {
         didSet { applyVisibility(isVisible) }
     }
 
-    private var panel: NSPanel?
+    /// One managed panel + its per-window model and observers/measurement state.
+    private final class ManagedPetWindow {
+        let panel: NSPanel
+        let model: PetWindowModel
+        var moveObserver: Any?
+
+        /// Screen position of the pet's bottom-center; kept stable across resizes.
+        var anchorBottomCenter: NSPoint?
+        var lastContentSize: CGSize = .zero
+        var resizeDebounce: DispatchWorkItem?
+
+        init(panel: NSPanel, model: PetWindowModel) {
+            self.panel = panel
+            self.model = model
+        }
+    }
+
+    /// All live pet panels, keyed by spec key.
+    private var windows: [String: ManagedPetWindow] = [:]
+
     private var sizeCancellable: AnyCancellable?
     private var chatLineCancellable: AnyCancellable?
     private var rightClickMonitor: Any?
     private var screenObserver: Any?
-    private var moveObserver: Any?
 
-    /// Screen position of the pet's bottom-center; kept stable across resizes.
-    private var anchorBottomCenter: NSPoint?
-    private var lastContentSize: CGSize = .zero
-    private var resizeDebounce: DispatchWorkItem?
+    private static let positionsKey = "agentpet.petPositions"
 
     func start() {
+        // Create the default ("home") window up front so the pet appears at
+        // launch, before the daemon's first session update arrives.
+        _ = ensureWindow(for: PetWindowPlanner.defaultKey)
+        applyVisibility(isVisible)
+
+        // On pet-size change, re-measure every window after SwiftUI relayouts.
+        sizeCancellable = PetController.shared.$petPoint.sink { [weak self] _ in
+            self?.remeasureAll()
+        }
+
+        // On agent rows added/removed, re-measure after SwiftUI relayouts.
+        chatLineCancellable = PetController.shared.$chatLineCount.sink { [weak self] _ in
+            self?.remeasureAll()
+        }
+
+        // If displays change (e.g. a monitor is unplugged), keep every pet on screen.
+        screenObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.ensureAllOnScreen() }
+        }
+
+        // Right-click a pet to show ITS stats card (info only — controls stay in
+        // the menu bar popover and Settings). Resolve which window via its panel.
+        rightClickMonitor = NSEvent.addLocalMonitorForEvents(matching: .rightMouseDown) { [weak self] event in
+            let handled = MainActor.assumeIsolated { () -> Bool in
+                guard let self,
+                      let managed = self.windows.values.first(where: { event.window === $0.panel }),
+                      let content = managed.panel.contentView else { return false }
+                // Anchor to the whole content rect so the popover sits entirely
+                // outside the window (above it) and never overlaps the pet.
+                self.showStatsPopover(relativeTo: content.bounds, of: content, petID: managed.model.petID)
+                return true
+            }
+            return handled ? nil : event
+        }
+    }
+
+    // MARK: - Multi-window sync
+
+    /// The per-window state the coordinator resolves for a spec: the displayed
+    /// mood (may differ from `spec.mood` — e.g. a transient celebrate burst),
+    /// the structured sessions for the bubble, the petID (after the missing-pet
+    /// fallback), and the chat line. Built by `PetController` from the existing
+    /// chat / celebrate logic.
+    struct WindowState {
+        var petID: String?
+        var mood: PetMood
+        var sessions: [AgentSession]
+        var count: Int
+        var chatLine: String
+    }
+
+    /// Reconciles the live panels with the planned specs. Existing keys update
+    /// their model in place (no new panel); new keys create a panel; keys absent
+    /// from `specs` are torn down. `stateFor` supplies the resolved per-window
+    /// state for each spec (computed by the coordinator from the existing chat /
+    /// celebrate logic).
+    func sync(specs: [PetWindowSpec], stateFor: (PetWindowSpec) -> WindowState) {
+        let wanted = Set(specs.map(\.key))
+
+        // Tear down windows whose group disappeared.
+        for key in windows.keys where !wanted.contains(key) {
+            teardownWindow(forKey: key)
+        }
+
+        for (index, spec) in specs.enumerated() {
+            let managed = windows[spec.key] ?? createWindow(
+                key: spec.key, petID: spec.petID, mood: spec.mood,
+                projectName: spec.projectName, count: spec.count, index: index)
+            apply(stateFor(spec), to: managed.model)
+            if isVisible { managed.panel.orderFrontRegardless() }
+        }
+    }
+
+    /// Pushes resolved state into a window's model. Keeps the `key` (immutable)
+    /// and only mutates the per-window published state.
+    private func apply(_ state: WindowState, to model: PetWindowModel) {
+        model.petID = state.petID
+        model.mood = state.mood
+        model.sessions = state.sessions
+        model.count = state.count
+        model.chatLine = state.chatLine
+    }
+
+    // MARK: - Window lifecycle
+
+    /// Returns the window for `key`, creating a bare default-anchored one if absent.
+    @discardableResult
+    private func ensureWindow(for key: String) -> ManagedPetWindow {
+        if let existing = windows[key] { return existing }
+        return createWindow(key: key, petID: PetController.shared.selectedPetID,
+                            mood: .idle, projectName: nil, count: 0, index: windows.count)
+    }
+
+    /// Builds a panel for a window key, positions it (saved position or
+    /// auto-offset), wires its move observer, registers it, and seeds its model.
+    /// The model's `sessions`/`chatLine` are filled immediately after by `sync`.
+    @discardableResult
+    private func createWindow(key: String, petID: String?, mood: PetMood,
+                              projectName: String?, count: Int, index: Int) -> ManagedPetWindow {
         let pet = PetController.shared.petPoint
         let size = CGSize(width: pet + 24, height: pet + 24)
+        let model = PetWindowModel(key: key, petID: petID, mood: mood,
+                                   projectName: projectName, count: count)
+        let panel = makePanel(size: size, model: model)
+        let managed = ManagedPetWindow(panel: panel, model: model)
+        windows[key] = managed
+
+        // Save position whenever the user drags this specific panel. Capture the
+        // Sendable `key` (not the non-Sendable `managed`) and re-resolve on the
+        // main actor to satisfy Swift 6 concurrency.
+        managed.moveObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didMoveNotification, object: panel, queue: .main
+        ) { [weak self, key] _ in
+            MainActor.assumeIsolated {
+                guard let self, let managed = self.windows[key] else { return }
+                self.syncAnchor(managed)
+                self.savePosition(managed)
+            }
+        }
+
+        placeWindow(managed, size: size, index: index)
+        syncAnchor(managed)
+        return managed
+    }
+
+    /// Factory: a borderless, non-activating, floating, click-through panel.
+    private func makePanel(size: CGSize, model: PetWindowModel) -> NSPanel {
         let panel = NSPanel(
             contentRect: NSRect(origin: .zero, size: size),
             styleMask: [.borderless, .nonactivatingPanel],
@@ -40,50 +185,56 @@ final class PetWindowController: ObservableObject {
         panel.isMovableByWindowBackground = true
         panel.becomesKeyOnlyIfNeeded = true
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
-        panel.contentView = ClickThroughHostingView(rootView: FloatingPetView())
-        self.panel = panel
+        panel.contentView = ClickThroughHostingView(rootView: FloatingPetView(model: model))
+        return panel
+    }
 
-        moveObserver = NotificationCenter.default.addObserver(
-            forName: NSWindow.didMoveNotification, object: panel, queue: .main
-        ) { [weak self] _ in
-            MainActor.assumeIsolated { self?.syncAnchorFromWindow() }
+    /// Loads a saved position for this window's key, else places it at the
+    /// bottom-right anchor shifted left by `index` so windows don't stack.
+    private func placeWindow(_ managed: ManagedPetWindow, size: CGSize, index: Int) {
+        if let origin = savedPosition(forKey: managed.model.key) {
+            managed.panel.setFrame(NSRect(origin: origin, size: size), display: true, animate: false)
+            return
         }
+        guard let visible = NSScreen.main?.visibleFrame else { return }
+        let step = PetController.shared.petPoint + 40
+        let origin = NSPoint(
+            x: visible.maxX - size.width - 16 - CGFloat(index) * step,
+            y: visible.minY + 24
+        )
+        managed.panel.setFrame(NSRect(origin: origin, size: size), display: true, animate: false)
+    }
 
-        placeInitially(size: size)
-        syncAnchorFromWindow()
-        applyVisibility(isVisible)
+    private func teardownWindow(forKey key: String) {
+        guard let managed = windows.removeValue(forKey: key) else { return }
+        managed.resizeDebounce?.cancel()
+        if let obs = managed.moveObserver { NotificationCenter.default.removeObserver(obs) }
+        managed.panel.orderOut(nil)
+    }
 
-        // On pet-size change, re-measure after SwiftUI relayouts.
-        sizeCancellable = PetController.shared.$petPoint.sink { [weak self] _ in
-            self?.remeasureContent()
-        }
+    // MARK: - Position persistence (agentpet.petPositions)
 
-        // On agent rows added/removed, re-measure after SwiftUI relayouts.
-        chatLineCancellable = PetController.shared.$chatLineCount.sink { [weak self] _ in
-            self?.remeasureContent()
-        }
+    private func loadPositions() -> [String: [Double]] {
+        guard let data = UserDefaults.standard.data(forKey: Self.positionsKey),
+              let decoded = try? JSONDecoder().decode([String: [Double]].self, from: data) else { return [:] }
+        return decoded
+    }
 
-        // If displays change (e.g. a monitor is unplugged), keep the pet on screen.
-        screenObserver = NotificationCenter.default.addObserver(
-            forName: NSApplication.didChangeScreenParametersNotification, object: nil, queue: .main
-        ) { [weak self] _ in
-            MainActor.assumeIsolated { self?.ensureOnScreen() }
-        }
+    private func savedPosition(forKey key: String) -> NSPoint? {
+        guard let xy = loadPositions()[key], xy.count == 2 else { return nil }
+        return NSPoint(x: xy[0], y: xy[1])
+    }
 
-        // Right-click the pet to show its stats card (info only — controls
-        // stay in the menu bar popover and Settings).
-        rightClickMonitor = NSEvent.addLocalMonitorForEvents(matching: .rightMouseDown) { [weak self] event in
-            let handled = MainActor.assumeIsolated { () -> Bool in
-                guard let self, let panel = self.panel, event.window === panel,
-                      let content = panel.contentView else { return false }
-                // Anchor to the whole content rect so the popover sits entirely
-                // outside the window (above it) and never overlaps the pet.
-                self.showStatsPopover(relativeTo: content.bounds, of: content)
-                return true
-            }
-            return handled ? nil : event
+    private func savePosition(_ managed: ManagedPetWindow) {
+        let origin = managed.panel.frame.origin
+        var all = loadPositions()
+        all[managed.model.key] = [Double(origin.x), Double(origin.y)]
+        if let data = try? JSONEncoder().encode(all) {
+            UserDefaults.standard.set(data, forKey: Self.positionsKey)
         }
     }
+
+    // MARK: - Stats popover (per window)
 
     /// Transient stats-only popover anchored at the pet.
     private var statsPopover: NSPopover?
@@ -93,7 +244,7 @@ final class PetWindowController: ObservableObject {
         statsPopover?.performClose(nil)
     }
 
-    private func showStatsPopover(relativeTo rect: NSRect, of view: NSView) {
+    private func showStatsPopover(relativeTo rect: NSRect, of view: NSView, petID: String?) {
         if let shown = statsPopover, shown.isShown {
             shown.performClose(nil)
             return
@@ -101,7 +252,7 @@ final class PetWindowController: ObservableObject {
         let popover = NSPopover()
         popover.behavior = .transient
         popover.animates = true
-        popover.contentViewController = NSHostingController(rootView: PetStatsView())
+        popover.contentViewController = NSHostingController(rootView: PetStatsView(petID: petID))
         statsPopover = popover
         // Prefer above the pet; AppKit flips to below only if there's no room.
         // In a flipped content view "above" is the minY edge.
@@ -113,49 +264,50 @@ final class PetWindowController: ObservableObject {
         popover.contentViewController?.view.window?.makeKey()
     }
 
-    /// First-time placement: bottom-right of the main screen.
-    private func placeInitially(size: CGSize) {
-        guard let panel, let visible = NSScreen.main?.visibleFrame else { return }
-        let origin = NSPoint(x: visible.maxX - size.width - 16, y: visible.minY + 24)
-        panel.setFrame(NSRect(origin: origin, size: size), display: true, animate: false)
-    }
+    // MARK: - Resize (per window)
 
-    /// Sizes the panel to hug the pet + bubble content.
-    func resizeToContent(_ size: CGSize) {
-        guard size.width > 0, size.height > 0 else { return }
+    /// Sizes the panel hosting `key` to hug the pet + bubble content.
+    func resizeToContent(_ size: CGSize, forKey key: String) {
+        guard size.width > 0, size.height > 0, let managed = windows[key] else { return }
 
-        resizeDebounce?.cancel()
+        managed.resizeDebounce?.cancel()
         let work = DispatchWorkItem { [weak self] in
-            self?.applyContentResize(size)
+            guard let self, let managed = self.windows[key] else { return }
+            self.applyContentResize(size, to: managed)
         }
-        resizeDebounce = work
+        managed.resizeDebounce = work
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05, execute: work)
     }
 
-    private func applyContentResize(_ size: CGSize) {
+    private func applyContentResize(_ size: CGSize, to managed: ManagedPetWindow) {
         let padded = CGSize(width: size.width + 4, height: size.height + 4)
-        let dw = abs(padded.width - lastContentSize.width)
-        let dh = abs(padded.height - lastContentSize.height)
-        guard dw > 1 || dh > 1 || lastContentSize == .zero else { return }
-        lastContentSize = padded
-        resizeInPlace(to: padded)
+        let dw = abs(padded.width - managed.lastContentSize.width)
+        let dh = abs(padded.height - managed.lastContentSize.height)
+        guard dw > 1 || dh > 1 || managed.lastContentSize == .zero else { return }
+        managed.lastContentSize = padded
+        resizeInPlace(managed, to: padded)
     }
 
-    private func remeasureContent() {
+    private func remeasureAll() {
+        for managed in windows.values { remeasureContent(managed) }
+    }
+
+    private func remeasureContent(_ managed: ManagedPetWindow) {
+        let key = managed.model.key
         DispatchQueue.main.async { [weak self] in
-            guard let host = self?.panel?.contentView as? NSHostingView<FloatingPetView> else { return }
+            guard let self, let managed = self.windows[key],
+                  let host = managed.panel.contentView as? ClickThroughHostingView<FloatingPetView> else { return }
             host.invalidateIntrinsicContentSize()
             host.layoutSubtreeIfNeeded()
             let size = host.fittingSize
             guard size.width > 0, size.height > 0 else { return }
-            self?.resizeToContent(size)
+            self.resizeToContent(size, forKey: key)
         }
     }
 
-    private func syncAnchorFromWindow() {
-        guard let panel else { return }
-        let frame = panel.frame
-        anchorBottomCenter = NSPoint(x: frame.midX, y: frame.minY)
+    private func syncAnchor(_ managed: ManagedPetWindow) {
+        let frame = managed.panel.frame
+        managed.anchorBottomCenter = NSPoint(x: frame.midX, y: frame.minY)
     }
 
     /// Resizes around a fixed bottom-center anchor so the pet doesn't drift.
@@ -164,10 +316,9 @@ final class PetWindowController: ObservableObject {
     /// origin to the screen: clamping a wide bubble back on-screen would shove
     /// the window , and therefore the pet , sideways. Keeping the pet put is
     /// more important than the bubble's far edge staying fully on-screen.
-    private func resizeInPlace(to size: CGSize) {
-        guard let panel else { return }
-        if anchorBottomCenter == nil { syncAnchorFromWindow() }
-        guard let anchor = anchorBottomCenter else { return }
+    private func resizeInPlace(_ managed: ManagedPetWindow, to size: CGSize) {
+        if managed.anchorBottomCenter == nil { syncAnchor(managed) }
+        guard let anchor = managed.anchorBottomCenter else { return }
 
         // X: keep the pet's centre fixed (no clamp -> no sideways jump).
         var origin = NSPoint(x: anchor.x - size.width / 2, y: anchor.y)
@@ -176,19 +327,22 @@ final class PetWindowController: ObservableObject {
         if let visible = currentScreen(for: probe)?.visibleFrame, origin.y + size.height > visible.maxY {
             origin.y = visible.maxY - size.height
         }
-        panel.setFrame(NSRect(origin: origin, size: size), display: true, animate: false)
+        managed.panel.setFrame(NSRect(origin: origin, size: size), display: true, animate: false)
     }
 
-    /// Keeps the pet visible after a display configuration change: if its
+    /// Keeps every pet visible after a display configuration change: if a pet's
     /// screen vanished (unplugged), move it onto the main screen.
-    private func ensureOnScreen() {
-        guard let panel else { return }
-        let frame = panel.frame
+    private func ensureAllOnScreen() {
+        for managed in windows.values { ensureOnScreen(managed) }
+    }
+
+    private func ensureOnScreen(_ managed: ManagedPetWindow) {
+        let frame = managed.panel.frame
         if currentScreen(for: frame) != nil { return }   // still on a live screen
         guard let visible = NSScreen.main?.visibleFrame else { return }
         let origin = NSPoint(x: visible.maxX - frame.width - 16, y: visible.minY + 24)
-        panel.setFrameOrigin(origin)
-        syncAnchorFromWindow()
+        managed.panel.setFrameOrigin(origin)
+        syncAnchor(managed)
     }
 
     /// The screen whose frame contains the window's center, if any.
@@ -198,10 +352,12 @@ final class PetWindowController: ObservableObject {
     }
 
     private func applyVisibility(_ visible: Bool) {
-        if visible {
-            panel?.orderFrontRegardless()
-        } else {
-            panel?.orderOut(nil)
+        for managed in windows.values {
+            if visible {
+                managed.panel.orderFrontRegardless()
+            } else {
+                managed.panel.orderOut(nil)
+            }
         }
     }
 }

--- a/Sources/App/PetWindowModel.swift
+++ b/Sources/App/PetWindowModel.swift
@@ -1,0 +1,37 @@
+import Foundation
+import AgentPetCore
+
+/// Per-window pet state. One instance backs each pet window (single window for
+/// now; the registry in later tasks owns one per active project). Holds only
+/// the fields that vary per window — global toggles (showChat, petPoint…) still
+/// live on `PetController.shared`.
+@MainActor
+final class PetWindowModel: ObservableObject {
+    /// Stable grouping key: a project path or `"default"` for the home pet.
+    let key: String
+
+    @Published var petID: String?
+    @Published var mood: PetMood
+    @Published var projectName: String?
+    @Published var sessions: [AgentSession]
+    @Published var count: Int
+    @Published var chatLine: String
+
+    init(
+        key: String,
+        petID: String? = nil,
+        mood: PetMood = .idle,
+        projectName: String? = nil,
+        sessions: [AgentSession] = [],
+        count: Int = 0,
+        chatLine: String = ""
+    ) {
+        self.key = key
+        self.petID = petID
+        self.mood = mood
+        self.projectName = projectName
+        self.sessions = sessions
+        self.count = count
+        self.chatLine = chatLine
+    }
+}

--- a/Sources/App/ProjectPetSettings.swift
+++ b/Sources/App/ProjectPetSettings.swift
@@ -1,0 +1,40 @@
+import Foundation
+import AgentPetCore
+
+@MainActor final class ProjectPetSettings: ObservableObject {
+    static let shared = ProjectPetSettings()
+    private static let key = "agentpet.projectPets"
+
+    @Published private(set) var mappings: [ProjectPetMapping] = []
+
+    init() { load() }
+
+    func setPet(projectPath: String, petID: String) {
+        let norm = ProjectPetResolver.normalize(projectPath)
+        var m = mappings.filter { ProjectPetResolver.normalize($0.projectPath) != norm }
+        m.append(ProjectPetMapping(projectPath: norm, petID: petID))
+        mappings = m.sorted { $0.projectPath < $1.projectPath }
+        save()
+    }
+
+    func remove(projectPath: String) {
+        let norm = ProjectPetResolver.normalize(projectPath)
+        mappings.removeAll { ProjectPetResolver.normalize($0.projectPath) == norm }
+        save()
+    }
+
+    func petID(forProject cwd: String?) -> String? {
+        ProjectPetResolver.mapping(forProject: cwd, mappings: mappings)?.petID
+    }
+
+    private func load() {
+        guard let data = UserDefaults.standard.data(forKey: Self.key),
+              let decoded = try? JSONDecoder().decode([ProjectPetMapping].self, from: data) else { return }
+        mappings = decoded
+    }
+    private func save() {
+        if let data = try? JSONEncoder().encode(mappings) {
+            UserDefaults.standard.set(data, forKey: Self.key)
+        }
+    }
+}

--- a/Sources/App/ProjectPetsView.swift
+++ b/Sources/App/ProjectPetsView.swift
@@ -1,0 +1,183 @@
+import AppKit
+import SwiftUI
+import AgentPetCore
+
+/// Edits the project→pet mappings stored in `ProjectPetSettings`.
+/// Listed in `PetTab` under the "Project pets" sub-tab.
+struct ProjectPetsView: View {
+    @ObservedObject var settings = ProjectPetSettings.shared
+    @ObservedObject var imagePets = ImagePetStore.shared
+
+    var body: some View {
+        Form {
+            if settings.mappings.isEmpty {
+                Section {
+                    VStack(spacing: 8) {
+                        Image(systemName: "folder.badge.questionmark")
+                            .font(.system(size: 32))
+                            .foregroundStyle(.secondary)
+                        Text("No project pets yet.")
+                            .font(.headline)
+                        Text("Add a project folder to give it its own pet.")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+                }
+            } else {
+                Section("Configured projects") {
+                    ForEach(settings.mappings, id: \.projectPath) { mapping in
+                        MappingRow(mapping: mapping, imagePets: imagePets, settings: settings)
+                    }
+                }
+            }
+
+            Section {
+                Button {
+                    addProject()
+                } label: {
+                    Label("Add project…", systemImage: "folder.badge.plus")
+                }
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    private func addProject() {
+        let panel = NSOpenPanel()
+        panel.title = "Choose Project Folder"
+        panel.prompt = "Add"
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.canCreateDirectories = false
+
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        let petID = PetController.shared.selectedPetID
+            ?? imagePets.packs.first?.id
+            ?? ""
+        guard !petID.isEmpty else { return }
+
+        settings.setPet(projectPath: url.path, petID: petID)
+    }
+}
+
+// MARK: - Single mapping row
+
+private struct MappingRow: View {
+    let mapping: ProjectPetMapping
+    @ObservedObject var imagePets: ImagePetStore
+    @ObservedObject var settings: ProjectPetSettings
+
+    private var folderName: String {
+        (mapping.projectPath as NSString).lastPathComponent
+    }
+
+    private var pack: ImagePetPack? {
+        imagePets.pack(id: mapping.petID)
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            // Thumbnail
+            thumbnail
+                .frame(width: 40, height: 40)
+                .background(RoundedRectangle(cornerRadius: 8).fill(.quaternary))
+
+            // Path info
+            VStack(alignment: .leading, spacing: 2) {
+                Text(folderName)
+                    .font(.callout.weight(.semibold))
+                    .lineLimit(1)
+                Text(mapping.projectPath)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+
+            Spacer()
+
+            // Pet picker
+            petPicker
+
+            // Delete button
+            Button {
+                settings.remove(projectPath: mapping.projectPath)
+            } label: {
+                Image(systemName: "trash")
+                    .foregroundStyle(.red.opacity(0.8))
+            }
+            .buttonStyle(.borderless)
+            .help("Remove this project mapping")
+        }
+        .padding(.vertical, 2)
+    }
+
+    @ViewBuilder
+    private var thumbnail: some View {
+        if let pack {
+            if let frame = pack.clip(0).first {
+                Image(nsImage: frame)
+                    .resizable()
+                    .interpolation(.high)
+                    .scaledToFit()
+                    .frame(width: 36, height: 36)
+            } else {
+                Image(systemName: "pawprint.fill")
+                    .foregroundStyle(.secondary)
+            }
+        } else {
+            VStack(spacing: 2) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.orange)
+                Text("missing")
+                    .font(.system(size: 8))
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var petPicker: some View {
+        if imagePets.packs.isEmpty {
+            Text("No pets installed")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        } else {
+            Menu {
+                ForEach(imagePets.packs) { p in
+                    Button {
+                        settings.setPet(projectPath: mapping.projectPath, petID: p.id)
+                    } label: {
+                        HStack {
+                            Text(p.displayName)
+                            if p.id == mapping.petID {
+                                Spacer()
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                }
+            } label: {
+                HStack(spacing: 4) {
+                    Text(pack?.displayName ?? "Missing pet")
+                        .font(.callout)
+                        .foregroundStyle(pack == nil ? .orange : .primary)
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(RoundedRectangle(cornerRadius: 6).fill(.quaternary))
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+        }
+    }
+}

--- a/Sources/App/SettingsDemoPanel.swift
+++ b/Sources/App/SettingsDemoPanel.swift
@@ -127,6 +127,7 @@ struct SettingsDemoPanel: View {
                 if pet.showChat {
                     if bubble.multiAgentBubbleEnabled && !activeSessions.isEmpty {
                         AgentBubble(sessions: activeSessions)
+                            .environment(\.animationsEnabled, pet.animationsEnabled)
                             .transition(.scale(scale: 0.7).combined(with: .opacity))
                     } else if !previewLine.isEmpty {
                         ChatBubble(text: previewLine)
@@ -151,7 +152,10 @@ struct SettingsDemoPanel: View {
     @ViewBuilder private var petSprite: some View {
         if let pack {
             let clip = bindings.clipIndex(packId: pack.id, clipCount: pack.clipCount, mood: mood)
-            ImageSpriteView(frames: pack.clip(clip), mood: mood, size: min(max(pet.petPoint, 80), 120))
+            ImageSpriteView(frames: pack.clip(clip), mood: mood,
+                            fps: pet.spriteFPS(forMood: mood),
+                            size: min(max(pet.petPoint, 80), 120))
+                .environment(\.animationsEnabled, pet.animationsEnabled)
         } else {
             VStack(spacing: 6) {
                 Image(systemName: "pawprint.fill").font(.system(size: 30)).foregroundStyle(.secondary)

--- a/Sources/App/SettingsDemoPanel.swift
+++ b/Sources/App/SettingsDemoPanel.swift
@@ -444,6 +444,8 @@ struct SettingsDemoPanel: View {
         case .waiting: return NSLocalizedString("Waiting", comment: "pet mood")
         case .done: return NSLocalizedString("Done", comment: "pet mood")
         case .celebrate: return NSLocalizedString("Celebrate", comment: "pet mood")
+        case .sleepy: return NSLocalizedString("Idle", comment: "pet mood")
+        case .levelup: return NSLocalizedString("Celebrate", comment: "pet mood")
         }
     }
 
@@ -453,6 +455,8 @@ struct SettingsDemoPanel: View {
         case .working: return .blue
         case .waiting: return .orange
         case .done, .celebrate: return .green
+        case .sleepy: return .secondary
+        case .levelup: return .green
         }
     }
 

--- a/Sources/App/SetupView.swift
+++ b/Sources/App/SetupView.swift
@@ -740,7 +740,7 @@ private struct AnimationPicker: View {
     @State private var state: PetMood = .working
     @State private var hoveredClip: Int?
 
-    private let states: [PetMood] = [.idle, .working, .waiting, .done, .celebrate]
+    private let states: [PetMood] = [.idle, .working, .waiting, .done, .celebrate, .sleepy, .levelup]
 
     var body: some View {
         Picker("State", selection: $state) {
@@ -790,6 +790,8 @@ private struct AnimationPicker: View {
         case .waiting: return NSLocalizedString("Waiting", comment: "pet mood")
         case .done: return NSLocalizedString("Done", comment: "pet mood")
         case .celebrate: return NSLocalizedString("Celebrate", comment: "pet mood")
+        case .sleepy: return NSLocalizedString("Sleepy", comment: "pet mood")
+        case .levelup: return NSLocalizedString("Level up", comment: "pet mood")
         }
     }
 }

--- a/Sources/App/SetupView.swift
+++ b/Sources/App/SetupView.swift
@@ -287,6 +287,33 @@ private struct GeneralTab: View {
                     Spacer()
                     ColorSwitch(isOn: $pet.splitPet)
                 }
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Animate pets")
+                        Text("Turn off to freeze pet/bubble animation (lower CPU).")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    ColorSwitch(isOn: $pet.animationsEnabled)
+                }
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Animation speed")
+                        Text("Sprite frame rate. Idle is always capped at 2 fps.")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    HStack(spacing: 8) {
+                        Slider(value: $pet.animationFPS, in: 1...12, step: 1)
+                            .frame(width: 120)
+                        Text("\(Int(pet.animationFPS)) fps")
+                            .monospacedDigit()
+                            .foregroundStyle(.secondary)
+                            .fixedSize()
+                    }
+                }
+                .disabled(!pet.animationsEnabled)
+                .opacity(pet.animationsEnabled ? 1 : 0.5)
             }
 
             Section("Notifications") {
@@ -541,7 +568,8 @@ private struct PetTab: View {
 
     @ViewBuilder private var petPreview: some View {
         if let pack = selectedPack {
-            ImageSpriteView(frames: pack.clip(0), mood: .idle, size: 78)
+            ImageSpriteView(frames: pack.clip(0), mood: .idle,
+                            fps: pet.spriteFPS(forMood: .idle), size: 78)
         } else {
             Image(systemName: "pawprint.fill").font(.system(size: 40)).foregroundStyle(.secondary)
         }
@@ -687,6 +715,7 @@ private struct PetThumb: View {
 private struct AnimationPicker: View {
     let pack: ImagePetPack
     @ObservedObject private var store = PetBindingsStore.shared
+    @ObservedObject private var pet = PetController.shared
     @State private var state: PetMood = .working
     @State private var hoveredClip: Int?
 
@@ -711,7 +740,8 @@ private struct AnimationPicker: View {
                     VStack(spacing: 3) {
                         Group {
                             if hoveredClip == i {
-                                ImageSpriteView(frames: pack.clip(i), mood: .working, size: 44)
+                                ImageSpriteView(frames: pack.clip(i), mood: .working,
+                                                fps: pet.spriteFPS(forMood: .working), size: 44)
                             } else {
                                 StaticFrame(image: pack.clip(i).first, size: 44)
                             }

--- a/Sources/App/SetupView.swift
+++ b/Sources/App/SetupView.swift
@@ -244,6 +244,7 @@ private struct GeneralTab: View {
     @ObservedObject var pet: PetController
     @ObservedObject private var sound = SoundSettings.shared
     @ObservedObject private var appLang = AppLanguage.shared
+    @ObservedObject private var breaks = BreakReminderSettings.shared
     // Local mirror of the system login-item state so the toggle re-renders
     // reliably (the SMAppService status isn't observable on its own).
     @State private var launchAtLogin = LoginItem.isEnabled
@@ -314,6 +315,26 @@ private struct GeneralTab: View {
                 }
                 .disabled(!pet.animationsEnabled)
                 .opacity(pet.animationsEnabled ? 1 : 0.5)
+            }
+
+            Section("Break reminder") {
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Remind me to take breaks")
+                        Text("The home pet nudges you to rest after a work stretch.")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    ColorSwitch(isOn: $breaks.enabled)
+                }
+                Stepper("Work for: \(breaks.workIntervalMinutes) min",
+                        value: $breaks.workIntervalMinutes, in: 15...240, step: 15)
+                    .disabled(!breaks.enabled)
+                    .opacity(breaks.enabled ? 1 : 0.5)
+                Stepper("Break length: \(breaks.breakLengthMinutes) min",
+                        value: $breaks.breakLengthMinutes, in: 1...30, step: 1)
+                    .disabled(!breaks.enabled)
+                    .opacity(breaks.enabled ? 1 : 0.5)
             }
 
             Section("Notifications") {

--- a/Sources/App/SetupView.swift
+++ b/Sources/App/SetupView.swift
@@ -277,6 +277,18 @@ private struct GeneralTab: View {
 }
             }
 
+            Section("Pet display") {
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Split pet")
+                        Text("Spawn one pet per active project instead of one shared pet.")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    ColorSwitch(isOn: $pet.splitPet)
+                }
+            }
+
             Section("Notifications") {
                 HStack {
                     VStack(alignment: .leading, spacing: 2) {
@@ -406,6 +418,9 @@ private struct PetTab: View {
     @State private var creating = false
     @State private var petQuery = ""
 
+    enum PetSubTab { case `default`, project }
+    @State private var petSubTab: PetSubTab = .default
+
     private var filteredPacks: [ImagePetPack] {
         guard !petQuery.isEmpty else { return imagePets.packs }
         let q = petQuery.lowercased()
@@ -413,6 +428,44 @@ private struct PetTab: View {
     }
 
     var body: some View {
+        VStack(spacing: 0) {
+            Picker("", selection: $petSubTab) {
+                Text("Default pet").tag(PetSubTab.default)
+                Text("Project pets").tag(PetSubTab.project)
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .padding(.horizontal, 16)
+            .padding(.top, 12)
+            .padding(.bottom, 8)
+
+            Divider()
+
+            Group {
+                if petSubTab == .default {
+                    defaultContent
+                } else {
+                    ProjectPetsView()
+                }
+            }
+            .frame(maxHeight: .infinity)
+        }
+        .sheet(isPresented: $browsing) {
+            BrowsePetsView(onClose: { browsing = false })
+        }
+        .sheet(isPresented: $creating) {
+            CreatePetView(
+                onCreate: { id in
+                    creating = false
+                    imagePets.reload()
+                    pet.selectedPetID = id
+                },
+                onCancel: { creating = false }
+            )
+        }
+    }
+
+    private var defaultContent: some View {
         Form {
             Section {
                 HStack(spacing: 14) {
@@ -484,19 +537,6 @@ private struct PetTab: View {
             }
         }
         .formStyle(.grouped)
-        .sheet(isPresented: $browsing) {
-            BrowsePetsView(onClose: { browsing = false })
-        }
-        .sheet(isPresented: $creating) {
-            CreatePetView(
-                onCreate: { id in
-                    creating = false
-                    imagePets.reload()
-                    pet.selectedPetID = id
-                },
-                onCancel: { creating = false }
-            )
-        }
     }
 
     @ViewBuilder private var petPreview: some View {

--- a/Tests/AgentPetAppTests/PetBindingsTests.swift
+++ b/Tests/AgentPetAppTests/PetBindingsTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import agentpet
+@testable import AgentPetCore
+
+final class PetBindingsTests: XCTestCase {
+    func testDefaultsIncludeNewMoods() {
+        let b = PetBindings.defaults(clipCount: 9)
+        XCTAssertNotNil(b.byMood[PetMood.sleepy.rawValue], "sleepy must get a default clip")
+        XCTAssertNotNil(b.byMood[PetMood.levelup.rawValue], "levelup must get a default clip")
+    }
+
+    func testDefaultsClampWithinClipBounds() {
+        let count = 3
+        let b = PetBindings.defaults(clipCount: count)
+        for mood in PetMood.allCases {
+            let idx = b.clipIndex(for: mood)
+            XCTAssertGreaterThanOrEqual(idx, 0)
+            XCTAssertLessThanOrEqual(idx, count - 1, "\(mood) clip index must stay within clip bounds")
+        }
+    }
+
+    func testZeroClipsYieldsZeroIndex() {
+        let b = PetBindings.defaults(clipCount: 0)
+        for mood in PetMood.allCases {
+            XCTAssertEqual(b.clipIndex(for: mood), 0, "\(mood) must fall back to clip 0 with no clips")
+        }
+    }
+}

--- a/Tests/AgentPetCoreTests/AcceptErrorActionTests.swift
+++ b/Tests/AgentPetCoreTests/AcceptErrorActionTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import AgentPetCore
+
+/// The accept loop must never spin a CPU core at 100% when `accept()` fails
+/// repeatedly. `acceptErrorAction` classifies the errno so the loop knows
+/// whether to retry, back off, or stop.
+final class AcceptErrorActionTests: XCTestCase {
+    func testInterruptedRetriesImmediately() {
+        XCTAssertEqual(EventSocketServer.acceptErrorAction(errno: EINTR), .retryImmediately)
+    }
+
+    func testConnectionAbortedRetriesImmediately() {
+        XCTAssertEqual(EventSocketServer.acceptErrorAction(errno: ECONNABORTED), .retryImmediately)
+    }
+
+    func testFileDescriptorExhaustionBacksOff() {
+        XCTAssertEqual(EventSocketServer.acceptErrorAction(errno: EMFILE), .backoff)
+        XCTAssertEqual(EventSocketServer.acceptErrorAction(errno: ENFILE), .backoff)
+    }
+
+    func testBadListenSocketStops() {
+        XCTAssertEqual(EventSocketServer.acceptErrorAction(errno: EBADF), .stop)
+        XCTAssertEqual(EventSocketServer.acceptErrorAction(errno: EINVAL), .stop)
+        XCTAssertEqual(EventSocketServer.acceptErrorAction(errno: ENOTSOCK), .stop)
+    }
+
+    func testUnknownErrorBacksOffRatherThanSpinning() {
+        // An unrecognised errno must never fall through to a tight retry loop.
+        XCTAssertEqual(EventSocketServer.acceptErrorAction(errno: 9999), .backoff)
+    }
+}

--- a/Tests/AgentPetCoreTests/BreakClockTests.swift
+++ b/Tests/AgentPetCoreTests/BreakClockTests.swift
@@ -1,0 +1,77 @@
+// Tests/AgentPetCoreTests/BreakClockTests.swift
+import XCTest
+@testable import AgentPetCore
+
+final class BreakClockTests: XCTestCase {
+    private let t0 = Date(timeIntervalSince1970: 0)
+    private func cfg(enabled: Bool = true, work: TimeInterval, brk: TimeInterval,
+                     maxDelta: TimeInterval = 300) -> BreakClockConfig {
+        BreakClockConfig(enabled: enabled, workInterval: work, breakLength: brk, maxDelta: maxDelta)
+    }
+
+    func testFiresBreakDueAfterWorkInterval() {
+        let c = BreakClock()
+        let k = cfg(work: 120, brk: 30)
+        XCTAssertEqual(c.tick(now: t0, isPresent: true, config: k), .none)        // active 0
+        XCTAssertEqual(c.tick(now: t0.addingTimeInterval(60), isPresent: true, config: k), .none)  // active 60
+        XCTAssertEqual(c.tick(now: t0.addingTimeInterval(120), isPresent: true, config: k), .breakDue) // active 120
+    }
+
+    func testAbsenceResetsClockSoNoNagAfterLunch() {
+        let c = BreakClock()
+        let k = cfg(work: 120, brk: 30)
+        _ = c.tick(now: t0, isPresent: true, config: k)                       // active 0
+        _ = c.tick(now: t0.addingTimeInterval(60), isPresent: true, config: k) // active 60
+        _ = c.tick(now: t0.addingTimeInterval(75), isPresent: false, config: k) // absence 15
+        _ = c.tick(now: t0.addingTimeInterval(90), isPresent: false, config: k) // absence 30 → reset
+        // back, present again: clock restarted, must NOT be due
+        XCTAssertEqual(c.tick(now: t0.addingTimeInterval(105), isPresent: true, config: k), .none)
+    }
+
+    func testFiresBreakOverAfterBreakLength() {
+        let c = BreakClock()
+        let k = cfg(work: 60, brk: 30)
+        _ = c.tick(now: t0, isPresent: true, config: k)                        // active 0
+        XCTAssertEqual(c.tick(now: t0.addingTimeInterval(60), isPresent: true, config: k), .breakDue) // resting since +60
+        XCTAssertEqual(c.tick(now: t0.addingTimeInterval(80), isPresent: true, config: k), .none)     // 20 < 30
+        XCTAssertEqual(c.tick(now: t0.addingTimeInterval(90), isPresent: true, config: k), .breakOver) // 30 >= 30
+    }
+
+    func testHugeDeltaResetsAndDoesNotFire() {
+        let c = BreakClock()
+        let k = cfg(work: 120, brk: 30, maxDelta: 300)
+        _ = c.tick(now: t0, isPresent: true, config: k)
+        _ = c.tick(now: t0.addingTimeInterval(60), isPresent: true, config: k)  // active 60
+        // machine slept 600s > maxDelta → reset, no break
+        XCTAssertEqual(c.tick(now: t0.addingTimeInterval(660), isPresent: true, config: k), .none)
+        _ = c.tick(now: t0.addingTimeInterval(720), isPresent: true, config: k) // active 60
+        XCTAssertEqual(c.tick(now: t0.addingTimeInterval(780), isPresent: true, config: k), .breakDue) // active 120
+    }
+
+    func testDisabledNeverFires() {
+        let c = BreakClock()
+        let k = cfg(enabled: false, work: 1, brk: 1)
+        XCTAssertEqual(c.tick(now: t0, isPresent: true, config: k), .none)
+        XCTAssertEqual(c.tick(now: t0.addingTimeInterval(10_000), isPresent: true, config: k), .none)
+    }
+
+    func testIntervalShrinkMidFlightFiresNextTick() {
+        let c = BreakClock()
+        var k = cfg(work: 600, brk: 30)
+        _ = c.tick(now: t0, isPresent: true, config: k)
+        _ = c.tick(now: t0.addingTimeInterval(60), isPresent: true, config: k)   // active 60
+        _ = c.tick(now: t0.addingTimeInterval(120), isPresent: true, config: k)  // active 120
+        k.workInterval = 100
+        XCTAssertEqual(c.tick(now: t0.addingTimeInterval(180), isPresent: true, config: k), .breakDue) // 180 >= 100
+    }
+
+    func testShortAbsenceKeepsAccumulatedTime() {
+        let c = BreakClock()
+        let k = cfg(work: 120, brk: 60)
+        _ = c.tick(now: t0, isPresent: true, config: k)                         // active 0
+        _ = c.tick(now: t0.addingTimeInterval(60), isPresent: true, config: k)  // active 60
+        _ = c.tick(now: t0.addingTimeInterval(75), isPresent: false, config: k) // absence 15 (<60), active kept
+        _ = c.tick(now: t0.addingTimeInterval(90), isPresent: true, config: k)  // active 60+15=75
+        XCTAssertEqual(c.tick(now: t0.addingTimeInterval(135), isPresent: true, config: k), .breakDue) // 75+45=120
+    }
+}

--- a/Tests/AgentPetCoreTests/PerKeyThrottleTests.swift
+++ b/Tests/AgentPetCoreTests/PerKeyThrottleTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import AgentPetCore
+
+final class PerKeyThrottleTests: XCTestCase {
+    func testFirstCallForKeyRuns() {
+        let throttle = PerKeyThrottle(interval: 10)
+        let t0 = Date(timeIntervalSince1970: 0)
+        XCTAssertTrue(throttle.shouldRun("a", now: t0), "the first call for a key must run")
+    }
+
+    func testSecondCallWithinIntervalIsSkipped() {
+        let throttle = PerKeyThrottle(interval: 10)
+        let t0 = Date(timeIntervalSince1970: 0)
+        _ = throttle.shouldRun("a", now: t0)
+        XCTAssertFalse(throttle.shouldRun("a", now: t0.addingTimeInterval(9)),
+                       "a call before the interval elapses must be skipped")
+    }
+
+    func testCallAfterIntervalRunsAgain() {
+        let throttle = PerKeyThrottle(interval: 10)
+        let t0 = Date(timeIntervalSince1970: 0)
+        _ = throttle.shouldRun("a", now: t0)
+        XCTAssertTrue(throttle.shouldRun("a", now: t0.addingTimeInterval(10)),
+                      "once the interval has elapsed the key runs again")
+    }
+
+    func testKeysAreIndependent() {
+        let throttle = PerKeyThrottle(interval: 10)
+        let t0 = Date(timeIntervalSince1970: 0)
+        _ = throttle.shouldRun("a", now: t0)
+        XCTAssertTrue(throttle.shouldRun("b", now: t0),
+                      "throttling one key must not block a different key")
+    }
+}

--- a/Tests/AgentPetCoreTests/PetWindowPlannerTests.swift
+++ b/Tests/AgentPetCoreTests/PetWindowPlannerTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import AgentPetCore
+
+final class PetWindowPlannerTests: XCTestCase {
+    private func s(_ id: String, _ state: AgentState, project: String?) -> AgentSession {
+        AgentSession(id: id, agentKind: .claude, project: project, state: state,
+                     source: .hook, updatedAt: Date(timeIntervalSince1970: 0))
+    }
+    private let cat = ProjectPetMapping(projectPath: "/work/foo", petID: "cat")
+
+    func testSplitOffSingleAggregateSpec() {
+        let specs = PetWindowPlanner.plan(
+            sessions: [s("1", .working, project: "/work/foo"), s("2", .waiting, project: "/x")],
+            split: false, mappings: [cat], defaultPetID: "boba")
+        XCTAssertEqual(specs.count, 1)
+        XCTAssertEqual(specs[0].key, "default")
+        XCTAssertEqual(specs[0].petID, "boba")
+        XCTAssertEqual(specs[0].mood, .working)      // working beats waiting
+        XCTAssertEqual(specs[0].count, 2)
+    }
+
+    func testSplitOffIdleWhenNothingActive() {
+        let specs = PetWindowPlanner.plan(sessions: [], split: false, mappings: [], defaultPetID: "boba")
+        XCTAssertEqual(specs.map(\.key), ["default"])
+        XCTAssertEqual(specs[0].mood, .idle)
+    }
+
+    func testSplitOnGroupsByProjectAndResolvesPet() {
+        let specs = PetWindowPlanner.plan(
+            sessions: [s("1", .working, project: "/work/foo/src"),   // matches cat
+                       s("2", .done, project: "/other")],            // unconfigured → default
+            split: true, mappings: [cat], defaultPetID: "boba")
+        let byKey = Dictionary(uniqueKeysWithValues: specs.map { ($0.key, $0) })
+        XCTAssertEqual(byKey["/work/foo"]?.petID, "cat")
+        XCTAssertEqual(byKey["/work/foo"]?.projectName, "foo")
+        XCTAssertEqual(byKey["/other"]?.petID, "boba")          // default sprite
+        XCTAssertEqual(byKey["/other"]?.mood, .done)
+        XCTAssertNil(byKey["default"])                          // PA2: no idle home when projects active
+    }
+
+    func testSplitOnSubfolderSessionsCollapseToConfiguredRoot() {
+        let specs = PetWindowPlanner.plan(
+            sessions: [s("1", .working, project: "/work/foo/a"), s("2", .working, project: "/work/foo/b")],
+            split: true, mappings: [cat], defaultPetID: "boba")
+        XCTAssertEqual(specs.count, 1)
+        XCTAssertEqual(specs[0].key, "/work/foo")
+        XCTAssertEqual(specs[0].count, 2)
+    }
+
+    func testSplitOnNoProjectSessionsGoToDefaultBucket() {
+        let specs = PetWindowPlanner.plan(
+            sessions: [s("1", .working, project: nil)],
+            split: true, mappings: [], defaultPetID: "boba")
+        XCTAssertEqual(specs.map(\.key), ["default"])
+        XCTAssertEqual(specs[0].petID, "boba")
+        XCTAssertEqual(specs[0].mood, .working)
+    }
+
+    func testSplitOnIdleHomeWhenNothingActive() {
+        let specs = PetWindowPlanner.plan(sessions: [], split: true, mappings: [cat], defaultPetID: "boba")
+        XCTAssertEqual(specs.map(\.key), ["default"])
+        XCTAssertEqual(specs[0].mood, .idle)
+    }
+
+    func testRegisteredAndIdleNotActive() {
+        let specs = PetWindowPlanner.plan(
+            sessions: [s("1", .idle, project: "/work/foo"), s("2", .registered, project: "/y")],
+            split: true, mappings: [cat], defaultPetID: "boba")
+        XCTAssertEqual(specs.map(\.key), ["default"])   // nothing active → idle home
+        XCTAssertEqual(specs[0].mood, .idle)
+    }
+}

--- a/Tests/AgentPetCoreTests/PetWindowPlannerTests.swift
+++ b/Tests/AgentPetCoreTests/PetWindowPlannerTests.swift
@@ -69,4 +69,28 @@ final class PetWindowPlannerTests: XCTestCase {
         XCTAssertEqual(specs.map(\.key), ["default"])   // nothing active → idle home
         XCTAssertEqual(specs[0].mood, .idle)
     }
+
+    func testForceDefaultAddsHomeWindowInSplitMode() {
+        // One active project session, split ON → normally only the project window.
+        let specs = PetWindowPlanner.plan(
+            sessions: [s("1", .working, project: "/work/foo")],
+            split: true, mappings: [cat], defaultPetID: "boba", forceDefault: true)
+        XCTAssertTrue(specs.contains { $0.key == "default" },
+                      "forceDefault must inject the home window for the break nudge")
+    }
+
+    func testForceDefaultDoesNotDuplicateExistingHome() {
+        // No active sessions → homeIdle already returns the default key.
+        let specs = PetWindowPlanner.plan(
+            sessions: [], split: true, mappings: [cat], defaultPetID: "boba", forceDefault: true)
+        XCTAssertEqual(specs.filter { $0.key == "default" }.count, 1,
+                       "forceDefault must not duplicate an existing home window")
+    }
+
+    func testForceDefaultOffKeepsCurrentBehaviour() {
+        let specs = PetWindowPlanner.plan(
+            sessions: [s("1", .working, project: "/work/foo")],
+            split: true, mappings: [cat], defaultPetID: "boba")   // forceDefault defaults false
+        XCTAssertFalse(specs.contains { $0.key == "default" })
+    }
 }

--- a/Tests/AgentPetCoreTests/ProjectPetResolverTests.swift
+++ b/Tests/AgentPetCoreTests/ProjectPetResolverTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import AgentPetCore
+
+final class ProjectPetResolverTests: XCTestCase {
+    private let cat = ProjectPetMapping(projectPath: "/work/foo", petID: "cat")
+    private let dog = ProjectPetMapping(projectPath: "/work/foo/api", petID: "dog")
+
+    func testExactMatch() {
+        XCTAssertEqual(ProjectPetResolver.mapping(forProject: "/work/foo", mappings: [cat])?.petID, "cat")
+    }
+    func testSubfolderMatches() {
+        XCTAssertEqual(ProjectPetResolver.mapping(forProject: "/work/foo/src", mappings: [cat])?.petID, "cat")
+    }
+    func testLongestMatchWins() {
+        XCTAssertEqual(ProjectPetResolver.mapping(forProject: "/work/foo/api/v1", mappings: [cat, dog])?.petID, "dog")
+    }
+    func testDirectoryBoundaryNotPrefixString() {
+        // "/work/foobar" must NOT match "/work/foo"
+        XCTAssertNil(ProjectPetResolver.mapping(forProject: "/work/foobar", mappings: [cat]))
+    }
+    func testTrailingSlashNormalized() {
+        XCTAssertEqual(ProjectPetResolver.mapping(forProject: "/work/foo/", mappings: [cat])?.petID, "cat")
+        let catSlash = ProjectPetMapping(projectPath: "/work/foo/", petID: "cat")
+        XCTAssertEqual(ProjectPetResolver.mapping(forProject: "/work/foo", mappings: [catSlash])?.petID, "cat")
+    }
+    func testNilOrEmptyCwdReturnsNil() {
+        XCTAssertNil(ProjectPetResolver.mapping(forProject: nil, mappings: [cat]))
+        XCTAssertNil(ProjectPetResolver.mapping(forProject: "", mappings: [cat]))
+    }
+    func testNoMatchReturnsNil() {
+        XCTAssertNil(ProjectPetResolver.mapping(forProject: "/other", mappings: [cat]))
+    }
+}


### PR DESCRIPTION
# Pet improvements: per-project pets, break reminder, moods, and CPU perf

5 self-contained improvements to AgentPet, each in its own commit. All build on
a universal binary (arm64 + x86_64); **244 XCTest pass, `swift build` clean**.

Commits (oldest → newest):

| Commit | Type | Summary |
|---|---|---|
| `perf(daemon)` | perf | Stop accept-loop CPU spin + throttle transcript reads |
| `feat` | feature | Per-project pets + split-pet mode |
| `perf(render)` | perf | Pet animation on CALayer + FPS controls |
| `feat` | feature | Break reminder |
| `feat` | feature | More moods (sleepy + levelup) |

> The features stack (break reminder and moods build on the per-project window
> machinery), so this is one PR with a clear per-commit history rather than
> separate PRs.

---

## 1. perf(daemon): stop accept-loop CPU spin + throttle transcript reads

**Problem:** with an agent running, the app could pin a CPU core (~100%).
Two causes: the socket accept loop busy-spun on transient errors, and the
per-event transcript title/model resolution re-read & re-parsed the transcript
on every hook event.

**Fix:**
- Accept loop classifies `errno` (`acceptErrorAction`) and backs off (50ms)
  instead of spinning; fatal errors stop the loop.
- Title resolved once then cached; model resolution throttled (`PerKeyThrottle`,
  30s); transcript reads are bounded (head/tail/offset, never full-file scan).

---

## 2. feat: per-project pets + split-pet mode

Assign a different pet per project and (optionally) show one pet per active
project instead of a single shared pet.

- **Project → pet mapping** with a longest-prefix resolver, persisted in
  `ProjectPetSettings`.
- **`PetWindowPlanner`** groups active sessions per project.
- **Split-pet toggle** spawns one floating window per active project via
  `PetWindowController` (each window is model-driven); single-pet mode is N=1.
- XP/feeding is routed to the pet actually shown for that project.
- Settings gain a **Pet** sub-tab (Default pet / Project pets) + a project
  picker; split bubbles show the project name to tell pets apart.

<img width="643" height="636" alt="image" src="https://github.com/user-attachments/assets/d0f14f32-f435-45ec-b441-e78fb8e799ff" />

---

## 3. perf(render): move pet animation to CALayer + FPS controls

**Problem:** an always-on-screen pet animating through a SwiftUI `TimelineView`
re-rendered the whole view tree every frame. Measured cost (old build):
**Animate ON ≈ 15% idle / ~30% while working** (and ~18–21% with two pets);
Animate OFF ≈ 0.7% idle. The animation itself was the dominant cost.

**Fix:** the pet sprite and the bubble state-dot now animate via
**CALayer / CAAnimation** on the render server — SwiftUI no longer redraws per
frame. Plus: sprite redraws at its mood's fps (idle capped at 2 fps), an
**Animate-pets** toggle to freeze all motion, an **animation-speed (fps)
slider**, a cheaper blur-free bubble, and the bubble now respects the Row
content layout (no forced project token).

**Result:** a busy pet dropped to **~3% CPU**.

<img width="640" height="386" alt="image" src="https://github.com/user-attachments/assets/7408c21e-0c69-4ead-ab2b-5f5de0a7186e" />

---

## 4. feat: break reminder

Opt-in reminder (default **off**) that nudges you to rest after a configurable
work stretch (default **90 min**, break **5 min**).

- A pure, deterministic **`BreakClock`** accumulates *active* time only —
  presence = keyboard/mouse input **or** an active agent — and auto-resets after
  an absence, so it never nags after lunch.
- On break: the **home/default pet** goes into a transient rest state (a
  notification + sound fire too); in split mode `forceDefault` keeps the home
  pet visible for the nudge; it perks back up after the break window.
- Disabling mid-break clears the rest state immediately.
- Configurable in **General → Break reminder** (toggle + work/break steppers).

<img width="640" height="307" alt="image" src="https://github.com/user-attachments/assets/531192b3-0d8e-4d75-b984-8186fcd923b9" />

---

## 5. feat: more moods (sleepy + levelup)

Two new pet moods, expressed by binding an existing spritesheet clip (no new art
required; a missing clip falls back to clip 0):

- **sleepy** — shown on the home pet while the break reminder rests it
  (animates at a low, calm fps).
- **levelup** — its own short burst when the pet levels up, distinct from the
  done-celebration.

Both are assignable per pack in **Pet → Animations** (new *Sleepy* / *Level up*
segments).

<img width="613" height="307" alt="image" src="https://github.com/user-attachments/assets/dbf3546d-d94a-425e-b35a-b904815a2481" />


---

## Testing

- `swift build` (universal arm64 + x86_64) — clean.
- `swift test` — **244 / 244 pass**. New deterministic unit tests:
  `BreakClockTests` (7), `PetWindowPlannerTests` (+3 for `forceDefault`),
  `ProjectPetResolverTests`, `PerKeyThrottleTests`, `AcceptErrorActionTests`,
  `PetBindingsTests` (3).

## Notes

- New moods reuse existing clips for now; dedicated sprites can be added later
  and simply bound in **Pet → Animations** — no code change needed.
- Break reminder and the new moods build on the per-project window machinery, so
  the commits are intended to land together in order.
