### PR TITLE
fix(codex): feed pet from Codex token count events

### DIFF
--- a/Sources/AgentPetCore/TranscriptReader.swift
+++ b/Sources/AgentPetCore/TranscriptReader.swift
@@ -84,10 +84,10 @@ public enum TranscriptReader {
         usageOffsets.removeAll()
     }
 
-    /// Sums the model usage tokens (input + output) that were *appended* to the
-    /// transcript since the previous call for the same path. The first call for
-    /// a path consumes the whole file. Feeds the pet: each Claude `Stop` reads
-    /// only the new bytes, so repeated calls are cheap even on big transcripts.
+    /// Sums the model usage tokens that were *appended* to the transcript since
+    /// the previous call for the same path. The first call for a path consumes
+    /// the whole file. Feeds the pet: each lifecycle hook reads only the new
+    /// bytes, so repeated calls are cheap even on big transcripts.
     ///
     /// Returns `nil` when the file can't be read; `0` when no new usage lines
     /// appeared.
@@ -117,14 +117,11 @@ public enum TranscriptReader {
         var total = 0
         for line in text.components(separatedBy: "\n") {
             // Fast reject: most lines carry no usage object at all.
-            guard line.contains("\"usage\"") else { continue }
+            guard line.contains("\"usage\"") || line.contains("\"token_count\"") else { continue }
             guard let data = line.data(using: .utf8),
-                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                  let message = json["message"] as? [String: Any],
-                  let usage = message["usage"] as? [String: Any]
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
             else { continue }
-            total += (usage["input_tokens"] as? Int ?? 0)
-            total += (usage["output_tokens"] as? Int ?? 0)
+            total += usageTokens(from: json)
         }
         return total
     }
@@ -257,6 +254,40 @@ public enum TranscriptReader {
         }
 
         return nil
+    }
+
+    private static func usageTokens(from json: [String: Any]) -> Int {
+        if let message = json["message"] as? [String: Any],
+           let usage = message["usage"] as? [String: Any] {
+            return max(0, intValue(usage["input_tokens"]) ?? 0)
+                + max(0, intValue(usage["output_tokens"]) ?? 0)
+        }
+
+        guard json["type"] as? String == "event_msg",
+              let payload = json["payload"] as? [String: Any],
+              payload["type"] as? String == "token_count",
+              let info = payload["info"] as? [String: Any],
+              let last = info["last_token_usage"] as? [String: Any]
+        else { return 0 }
+
+        if let total = intValue(last["total_tokens"]) {
+            return max(0, total)
+        }
+        return max(0, intValue(last["input_tokens"]) ?? 0)
+            + max(0, intValue(last["output_tokens"]) ?? 0)
+    }
+
+    private static func intValue(_ value: Any?) -> Int? {
+        switch value {
+        case let int as Int:
+            return int
+        case let number as NSNumber:
+            return number.intValue
+        case let double as Double:
+            return Int(double)
+        default:
+            return nil
+        }
     }
 
     private static func cleanRecap(_ text: String) -> String? {

--- a/Sources/App/AppDaemon.swift
+++ b/Sources/App/AppDaemon.swift
@@ -78,20 +78,22 @@ final class AppDaemon: ObservableObject {
         refresh()
     }
 
-    /// Tokens appear in the transcript while Claude is still working, so the
-    /// pet eats live on tool events instead of waiting for `Stop`. Throttled
-    /// per session; reads are incremental (offset-based), so the `Stop` path
-    /// picking up the remainder never double-counts.
+    /// Tokens appear in supported transcripts while the agent is still working,
+    /// so the pet eats live on tool events and at Codex `Stop`. Throttled per
+    /// session while live; reads are incremental (offset-based), so the `Stop`
+    /// path picking up the remainder never double-counts.
     private var lastLiveFeed: [String: Date] = [:]
     private static let liveFeedInterval: TimeInterval = 10
 
     private func feedLiveTokens(for event: AgentEvent) {
-        guard event.agentKind == .claude, event.eventName != "Stop" else { return }
-        let path: String? = event.transcriptPath
-            ?? event.project.map { TranscriptReader.inferredPath(sessionId: event.sessionId, cwd: $0) }
+        guard [.claude, .codex].contains(event.agentKind),
+              !(event.agentKind == .claude && event.eventName == "Stop")
+        else { return }
+        let path = transcriptPath(for: event)
         guard let path else { return }
         let now = Date()
-        if let last = lastLiveFeed[event.sessionId],
+        if event.eventName != "Stop",
+           let last = lastLiveFeed[event.sessionId],
            now.timeIntervalSince(last) < Self.liveFeedInterval { return }
         lastLiveFeed[event.sessionId] = now
         Task.detached(priority: .utility) {
@@ -107,8 +109,7 @@ final class AppDaemon: ObservableObject {
     private func refineDoneIfQuestion(event: AgentEvent, before: AgentState?, session: AgentSession) {
         let sessionId = event.sessionId
         let stateSince = session.stateSince
-        let path: String? = event.transcriptPath
-            ?? event.project.map { TranscriptReader.inferredPath(sessionId: sessionId, cwd: $0) }
+        let path = transcriptPath(for: event)
         guard let path else {
             notifyIfNeeded(before: before, session: session)
             return
@@ -133,8 +134,7 @@ final class AppDaemon: ObservableObject {
 
     private func resolveTitle(for event: AgentEvent) {
         let sessionId = event.sessionId
-        let path: String? = event.transcriptPath
-            ?? event.project.map { TranscriptReader.inferredPath(sessionId: sessionId, cwd: $0) }
+        let path = transcriptPath(for: event)
         guard let path else { return }
         Task.detached(priority: .utility) { [weak self] in
             guard let title = TranscriptReader.title(at: path) else { return }
@@ -151,8 +151,7 @@ final class AppDaemon: ObservableObject {
     private func resolveModel(for event: AgentEvent) {
         guard event.agentKind == .claude else { return }
         let sessionId = event.sessionId
-        let path: String? = event.transcriptPath
-            ?? event.project.map { TranscriptReader.inferredPath(sessionId: sessionId, cwd: $0) }
+        let path = transcriptPath(for: event)
         guard let path else { return }
         Task.detached(priority: .utility) { [weak self] in
             guard let model = TranscriptReader.latestAssistantModel(at: path) else { return }
@@ -161,6 +160,12 @@ final class AppDaemon: ObservableObject {
                 self?.refresh()
             }
         }
+    }
+
+    private func transcriptPath(for event: AgentEvent) -> String? {
+        if let transcriptPath = event.transcriptPath { return transcriptPath }
+        guard event.agentKind == .claude, let project = event.project else { return nil }
+        return TranscriptReader.inferredPath(sessionId: event.sessionId, cwd: project)
     }
 
     private func notifyIfNeeded(before: AgentState?, session: AgentSession) {

--- a/Sources/App/PetCareController.swift
+++ b/Sources/App/PetCareController.swift
@@ -68,7 +68,7 @@ final class PetCareController: ObservableObject {
         mutateCurrent { PetCare.recordMeal(state: &$0, now: Date()) }
     }
 
-    /// Tokens consumed by a Claude turn (transcript usage delta).
+    /// Tokens consumed by an agent turn (transcript usage delta).
     func feedTokens(_ tokens: Int) {
         guard tokens > 0 else { return }
         mutateCurrent { PetCare.feedTokens(tokens, state: &$0, now: Date()) }

--- a/Sources/App/PetView.swift
+++ b/Sources/App/PetView.swift
@@ -109,7 +109,9 @@ struct FloatingPetView: View {
             }
         )
         .onPreferenceChange(PetContentSizeKey.self) { size in
-            PetWindowController.shared.resizeToContent(size)
+            Task { @MainActor in
+                PetWindowController.shared.resizeToContent(size)
+            }
         }
         .animation(.easeInOut(duration: 0.22), value: pet.chatLine)
         .animation(.spring(response: 0.35, dampingFraction: 0.7), value: pet.activeAgentSessions.count)

--- a/Tests/AgentPetCoreTests/TranscriptUsageTests.swift
+++ b/Tests/AgentPetCoreTests/TranscriptUsageTests.swift
@@ -31,6 +31,10 @@ final class TranscriptUsageTests: XCTestCase {
         #"{"type":"assistant","message":{"usage":{"input_tokens":\#(input),"output_tokens":\#(output)},"content":[{"type":"text","text":"hi"}]}}"#
     }
 
+    private func codexTokenCountLine(total: Int, input: Int = 0, output: Int = 0) -> String {
+        #"{"timestamp":"2026-06-24T08:43:29.999Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":999,"output_tokens":111,"total_tokens":1110},"last_token_usage":{"input_tokens":\#(input),"cached_input_tokens":0,"output_tokens":\#(output),"reasoning_output_tokens":0,"total_tokens":\#(total)},"model_context_window":258400},"rate_limits":{"limit_id":"codex"}}}"#
+    }
+
     func testSumsUsageAcrossLines() {
         append([
             #"{"type":"user","message":{"content":"do the thing"}}"#,
@@ -54,6 +58,22 @@ final class TranscriptUsageTests: XCTestCase {
             #"{"type":"summary","summary":"A chat"}"#,
         ])
         XCTAssertEqual(TranscriptReader.newUsageTokens(at: path), 0)
+    }
+
+    func testSumsCodexTokenCountEvents() {
+        append([
+            #"{"timestamp":"2026-06-24T08:43:20.000Z","type":"response_item","payload":{"type":"message"}}"#,
+            codexTokenCountLine(total: 20_565, input: 19_901, output: 664),
+            codexTokenCountLine(total: 5_100, input: 5_000, output: 100),
+        ])
+        XCTAssertEqual(TranscriptReader.newUsageTokens(at: path), 25_665)
+    }
+
+    func testCodexTokenCountFallsBackToInputPlusOutput() {
+        append([
+            #"{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":3000,"output_tokens":250}}}}"#,
+        ])
+        XCTAssertEqual(TranscriptReader.newUsageTokens(at: path), 3_250)
     }
 
     func testPartialTrailingLineIsLeftForNextCall() {


### PR DESCRIPTION
## Summary

This PR fixes Codex token feeding for AgentPet.

Previously, AgentPet only fed pet token stats from Claude-style transcript usage lines:

```json
{"message":{"usage":{"input_tokens":1000,"output_tokens":250}}}
```

Codex hook events can provide a `transcript_path`, but current Codex session transcripts store per-turn usage as `event_msg` / `token_count` payloads with `payload.info.last_token_usage.total_tokens`. AgentPet did not parse that shape, and live token feeding was guarded to `.claude` only.

This change:

- Keeps existing Claude transcript parsing unchanged.
- Adds Codex `event_msg` / `token_count` parsing in `TranscriptReader`.
- Feeds tokens for Codex when hook events include a transcript path.
- Limits inferred Claude transcript paths to Claude only, so other CLIs/IDEs do not accidentally read `~/.claude/...`.
- Fixes a Swift 6 main-actor compile blocker in `PetView`.
- Adds unit coverage for Codex token count transcript events.

## Research Proof

Official OpenAI Codex hook docs confirm command hooks receive a JSON object on stdin, including:

- `session_id`
- `transcript_path`
- `cwd`
- `hook_event_name`
- `model`

Source: https://developers.openai.com/codex/hooks

The same docs explicitly state that `transcript_path` points to a conversation transcript, but the transcript format is not a stable hook interface and may change over time.

Source: https://developers.openai.com/codex/hooks

Official Codex CLI docs confirm `/status` displays current token usage and `/usage` can show account token activity with daily, weekly, or cumulative views.

Source: https://developers.openai.com/codex/cli/slash-commands

OpenAI Help confirms Codex usage counts toward the account's agentic usage limit, so tracking Codex token/activity in AgentPet maps to real Codex usage behavior.

Source: https://help.openai.com/en/articles/11369540-using-codex-with-your-chatgpt-plan

Local verification on Codex CLI 0.140.0 found session transcripts under `~/.codex/sessions/**/rollout-*.jsonl` containing:

```json
{
  "type": "event_msg",
  "payload": {
    "type": "token_count",
    "info": {
      "last_token_usage": {
        "input_tokens": 19901,
        "cached_input_tokens": 4992,
        "output_tokens": 664,
        "reasoning_output_tokens": 267,
        "total_tokens": 20565
      }
    }
  }
}
```

Because OpenAI documents the transcript format as unstable, the parser is additive and tolerant:

- Prefer `last_token_usage.total_tokens`.
- Fall back to `input_tokens + output_tokens`.
- Ignore unknown/non-usage transcript lines.

## Code Notes

Changed files:

- `Sources/AgentPetCore/TranscriptReader.swift`
- `Sources/App/AppDaemon.swift`
- `Sources/App/PetCareController.swift`
- `Sources/App/PetView.swift`
- `Tests/AgentPetCoreTests/TranscriptUsageTests.swift`

Behavior boundaries:

- Claude behavior remains covered by existing `message.usage.input_tokens/output_tokens` tests.
- Codex is the only newly enabled non-Claude token-feeding path.
- Other agents are not opted into token feeding by this PR.
- Hook install/config formats are not changed.
- State mapping is not changed.

## Testing

```bash
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter TranscriptUsageTests
```

Result: pass, 7 tests.

```bash
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
```

Result: pass, 254 tests.

## Risk

Low for existing agents. The app only feeds live tokens for `.claude` and `.codex`, and the Codex path requires a transcript path from the hook.

Medium future-maintenance risk for Codex transcript parsing because OpenAI documents the transcript format as not stable. The implementation is intentionally defensive and covered by unit tests for the current observed shape.
