### PR TITLE
fix(care): level-up bubble shows display level, not internal level

### DIFF
--- a/Sources/App/PetCareController.swift
+++ b/Sources/App/PetCareController.swift
@@ -108,7 +108,7 @@ final class PetCareController: ObservableObject {
         if levelAfter > levelBefore {
             let line = String(
                 format: NSLocalizedString("Level up! Lv %d ⭐", comment: "pet level-up celebrate line"),
-                levelAfter
+                PetCare.displayLevel(forXP: s.xp)
             )
             PetController.shared.flashLevelUp(line: line, petID: petID)
         }


### PR DESCRIPTION
## Problem

When a pet levels up, the celebrate bubble announces a level one higher than what the app shows everywhere else. E.g. a pet going from Lv 5 to Lv 6 (as shown in the Care tab / HUD) flashes "Level up! Lv 7 ⭐".

## Cause

Every user-facing surface formats the **display level** via `PetCare.displayLevel(forXP:)` (internal level minus one, so a brand-new pet reads Lv 0). The level-up bubble in `PetCareController.mutate` was the one spot formatting the raw internal `PetCare.level(forXP:)` instead, so it always read one level high.

## Fix

Format the bubble line with `PetCare.displayLevel(forXP: s.xp)`. The level-up detection itself still compares internal levels, which is unaffected (the delta is identical).

One-line change; `swift build` and all 308 tests pass.