### PR TITLE
feat: add local estimated USD cost tracking (session/monthly)

### DIFF
--- a/Localizations/en.lproj/Localizable.strings
+++ b/Localizations/en.lproj/Localizable.strings
@@ -275,6 +275,7 @@
 "Full! The daily bowl is empty." = "Full! The daily bowl is empty.";
 "Sessions finished" = "Sessions finished";
 "Streak" = "Streak";
+"Est. cost (Claude)" = "Est. cost (Claude)";
 "%d days" = "%d days";
 "Total tokens eaten" = "Total tokens eaten";
 "Total sessions" = "Total sessions";

--- a/Sources/AgentPetCore/ModelPricing.swift
+++ b/Sources/AgentPetCore/ModelPricing.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Per-million-token USD pricing for Claude model tiers, used to estimate the
+/// cost of usage tokens recorded in a transcript.
+public enum ModelPricing {
+    public static func costUSD(
+        model: String?,
+        inputTokens: Int,
+        outputTokens: Int,
+        cacheCreateTokens: Int,
+        cacheReadTokens: Int
+    ) -> Double {
+        let lowered = model?.lowercased() ?? ""
+        let (inputRate, outputRate): (Double, Double)
+        if lowered.contains("haiku") {
+            (inputRate, outputRate) = (1.00, 5.00)
+        } else if lowered.contains("opus") {
+            (inputRate, outputRate) = (15.00, 75.00)
+        } else {
+            (inputRate, outputRate) = (3.00, 15.00)
+        }
+
+        return (Double(inputTokens) * inputRate
+            + Double(outputTokens) * outputRate
+            + Double(cacheCreateTokens) * inputRate * 1.25
+            + Double(cacheReadTokens) * inputRate * 0.1) / 1_000_000
+    }
+}

--- a/Sources/AgentPetCore/TranscriptReader.swift
+++ b/Sources/AgentPetCore/TranscriptReader.swift
@@ -19,6 +19,15 @@ public enum TranscriptReader {
     nonisolated(unsafe) private static var recapCache: [String: String] = [:]
     // Byte offset already consumed by `newUsageTokens` per transcript path.
     nonisolated(unsafe) private static var usageOffsets: [String: UInt64] = [:]
+    // Guards `usageOffsets` and the token/cost scan against concurrent callers.
+    private static let stateLock = NSLock()
+
+    /// Tokens + estimated USD cost computed together from one scan, so callers
+    /// never observe a token count paired with a mismatched cost.
+    public struct UsageDelta: Equatable {
+        public let tokens: Int
+        public let costUSD: Double
+    }
 
     /// Returns the title for the transcript at `path`, or `nil` if unreadable.
     public static func title(at path: String) -> String? {
@@ -79,42 +88,51 @@ public enum TranscriptReader {
 
     /// Clears cached titles — useful after fixing the extraction logic at runtime.
     public static func clearCache() {
+        stateLock.lock()
+        defer { stateLock.unlock() }
         summaryCache.removeAll()
         recapCache.removeAll()
         usageOffsets.removeAll()
     }
 
-    /// Sums the model usage tokens (input + output) that were *appended* to the
-    /// transcript since the previous call for the same path. The first call for
-    /// a path consumes the whole file. Feeds the pet: each Claude `Stop` reads
-    /// only the new bytes, so repeated calls are cheap even on big transcripts.
-    ///
-    /// Returns `nil` when the file can't be read; `0` when no new usage lines
-    /// appeared.
+    /// Sums the model usage tokens (input + output) appended since the previous call for `path`. The first call consumes the whole file; returns `nil` if unreadable, `0` if nothing new.
     public static func newUsageTokens(at path: String) -> Int? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return scanUsageDelta(path)?.tokens
+    }
+
+    /// Same scan as `newUsageTokens`, but returns tokens and estimated USD cost together from one pass so the two values can never mismatch. `nil` when unreadable.
+    public static func newUsageDelta(at path: String) -> UsageDelta? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return scanUsageDelta(path)
+    }
+
+    // Advances usageOffsets[path] past every complete new line and returns the summed tokens/cost. Callers must hold stateLock.
+    private static func scanUsageDelta(_ path: String) -> UsageDelta? {
         guard let handle = FileHandle(forReadingAtPath: path) else { return nil }
         defer { try? handle.close() }
 
         let size = (try? handle.seekToEnd()) ?? 0
         var start = usageOffsets[path] ?? 0
         if start > size { start = 0 }   // truncated/replaced file: start over
-        guard size > start else { return 0 }
+        guard size > start else { return UsageDelta(tokens: 0, costUSD: 0) }
 
         try? handle.seek(toOffset: start)
         let raw = handle.readDataToEndOfFile()
-
-        // Only consume up to the last full line; a partial trailing line (still
-        // being written) is left for the next call.
+        // Only consume up to the last full line; a partial trailing line is left for the next call.
         let consumable: Data
         if let nl = raw.lastIndex(of: UInt8(ascii: "\n")) {
             consumable = raw[raw.startIndex...nl]
         } else {
-            return 0
+            return UsageDelta(tokens: 0, costUSD: 0)
         }
         usageOffsets[path] = start + UInt64(consumable.count)
 
-        guard let text = String(data: consumable, encoding: .utf8) else { return 0 }
+        guard let text = String(data: consumable, encoding: .utf8) else { return UsageDelta(tokens: 0, costUSD: 0) }
         var total = 0
+        var costAccumulator = 0.0
         for line in text.components(separatedBy: "\n") {
             // Fast reject: most lines carry no usage object at all.
             guard line.contains("\"usage\"") else { continue }
@@ -123,10 +141,19 @@ public enum TranscriptReader {
                   let message = json["message"] as? [String: Any],
                   let usage = message["usage"] as? [String: Any]
             else { continue }
-            total += (usage["input_tokens"] as? Int ?? 0)
-            total += (usage["output_tokens"] as? Int ?? 0)
+            let inputTokens = usage["input_tokens"] as? Int ?? 0
+            let outputTokens = usage["output_tokens"] as? Int ?? 0
+            total += inputTokens
+            total += outputTokens
+            costAccumulator += ModelPricing.costUSD(
+                model: message["model"] as? String,
+                inputTokens: inputTokens,
+                outputTokens: outputTokens,
+                cacheCreateTokens: usage["cache_creation_input_tokens"] as? Int ?? 0,
+                cacheReadTokens: usage["cache_read_input_tokens"] as? Int ?? 0
+            )
         }
-        return total
+        return UsageDelta(tokens: total, costUSD: costAccumulator)
     }
 
     // MARK: - Codex (rollout) usage

--- a/Sources/App/AppDaemon.swift
+++ b/Sources/App/AppDaemon.swift
@@ -110,12 +110,11 @@ final class AppDaemon: ObservableObject {
             lastLiveFeed[event.sessionId] = now
             let project = event.project
             Task.detached(priority: .utility) {
-                let tokens = TranscriptReader.newUsageTokens(at: path) ?? 0
-                guard tokens > 0 else { return }
+                guard let delta = TranscriptReader.newUsageDelta(at: path), delta.tokens > 0 else { return }
                 await MainActor.run {
-                    PetCareController.shared.feedTokens(tokens,
+                    PetCareController.shared.feedTokens(delta.tokens,
                         petID: AppDaemon.shared.careTarget(forProject: project))
-                    ProjectUsageStore.shared.recordTokens(tokens, project: project, agent: "claude")
+                    ProjectUsageStore.shared.recordTokens(delta.tokens, project: project, agent: "claude", costUSD: delta.costUSD)
                 }
             }
         case .codex:
@@ -136,12 +135,11 @@ final class AppDaemon: ObservableObject {
         let project = event.project
         let agent = event.agentKind.rawValue
         Task.detached(priority: .utility) {
-            let tokens = TranscriptReader.newUsageTokens(at: path) ?? 0
-            guard tokens > 0 else { return }
+            guard let delta = TranscriptReader.newUsageDelta(at: path), delta.tokens > 0 else { return }
             await MainActor.run {
-                PetCareController.shared.feedTokens(tokens,
+                PetCareController.shared.feedTokens(delta.tokens,
                     petID: AppDaemon.shared.careTarget(forProject: project))
-                ProjectUsageStore.shared.recordTokens(tokens, project: project, agent: agent)
+                ProjectUsageStore.shared.recordTokens(delta.tokens, project: project, agent: agent, costUSD: delta.costUSD)
             }
         }
     }
@@ -191,12 +189,12 @@ final class AppDaemon: ObservableObject {
             let isQuestion = TranscriptReader.latestAssistantText(at: path)
                 .map(QuestionDetector.looksLikeQuestion) ?? false
             // The turn just ended either way — feed the pet the tokens it burnt.
-            let tokens = TranscriptReader.newUsageTokens(at: path) ?? 0
+            let delta = TranscriptReader.newUsageDelta(at: path)
             await MainActor.run { [weak self] in
                 guard let self else { return }
-                PetCareController.shared.feedTokens(tokens,
+                PetCareController.shared.feedTokens(delta?.tokens ?? 0,
                     petID: self.careTarget(forProject: project))
-                ProjectUsageStore.shared.recordTokens(tokens, project: project, agent: "claude")
+                ProjectUsageStore.shared.recordTokens(delta?.tokens ?? 0, project: project, agent: "claude", costUSD: delta?.costUSD ?? 0)
                 if isQuestion {
                     self.store.refineState(id: sessionId, from: .done, to: .waiting, since: stateSince)
                 }

--- a/Sources/App/PetStatsView.swift
+++ b/Sources/App/PetStatsView.swift
@@ -12,6 +12,7 @@ struct PetStatsView: View {
     @ObservedObject private var pet = PetController.shared
     @ObservedObject private var imagePets = ImagePetStore.shared
     @ObservedObject private var usage = OpenUsageClient.shared
+    @ObservedObject private var usageStore = ProjectUsageStore.shared
     @ObservedObject private var updater = UpdaterController.shared
     @State private var updateLabel: String?
     @State private var hoveredAchievement: Achievement?
@@ -43,6 +44,7 @@ struct PetStatsView: View {
             achievementBlock
             statGrid(state)
             trendBlock(state)
+            costBlock
             usageBlock
             if let last = state.lastFedAt {
                 HStack {
@@ -287,6 +289,23 @@ struct PetStatsView: View {
             }
             .frame(height: 48, alignment: .bottom)
         }
+    }
+
+    // MARK: - Cost
+
+    private var costBlock: some View {
+        HStack {
+            Text("Est. cost (Claude)")
+                .font(.system(size: 9, weight: .semibold)).tracking(0.8)
+                .foregroundStyle(.white.opacity(0.35))
+            Spacer()
+            Text(verbatim: "Today \(Self.costString(usageStore.todayCostUSD)) · Month \(Self.costString(usageStore.monthlyCostUSD))")
+                .font(.system(size: 9, weight: .semibold)).foregroundStyle(.white.opacity(0.55))
+        }
+    }
+
+    private static func costString(_ usd: Double) -> String {
+        String(format: "$%.2f", usd)
     }
 
     // MARK: - Usage / limits

--- a/Sources/App/ProjectUsageStore.swift
+++ b/Sources/App/ProjectUsageStore.swift
@@ -15,6 +15,33 @@ final class ProjectUsageStore: ObservableObject {
         var day: String
         var tokens: Int
         var sessions: Int
+        var costUSD: Double = 0
+
+        init(projectId: String, projectName: String, agent: String, day: String, tokens: Int, sessions: Int, costUSD: Double = 0) {
+            self.projectId = projectId
+            self.projectName = projectName
+            self.agent = agent
+            self.day = day
+            self.tokens = tokens
+            self.sessions = sessions
+            self.costUSD = costUSD
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case projectId, projectName, agent, day, tokens, sessions, costUSD
+        }
+
+        /// Custom decode so rows persisted before costUSD existed still load, defaulting to 0.
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            projectId = try c.decode(String.self, forKey: .projectId)
+            projectName = try c.decode(String.self, forKey: .projectName)
+            agent = try c.decode(String.self, forKey: .agent)
+            day = try c.decode(String.self, forKey: .day)
+            tokens = try c.decode(Int.self, forKey: .tokens)
+            sessions = try c.decode(Int.self, forKey: .sessions)
+            costUSD = try c.decodeIfPresent(Double.self, forKey: .costUSD) ?? 0
+        }
     }
 
     private static let storageKey = "agentpet.projectUsage"
@@ -23,23 +50,27 @@ final class ProjectUsageStore: ObservableObject {
     private var rows: [String: Row]
     private var dirty: Set<String>
 
+    @Published private(set) var todayCostUSD: Double = 0
+    @Published private(set) var monthlyCostUSD: Double = 0
+
     init() {
         rows = (UserDefaults.standard.data(forKey: Self.storageKey)
             .flatMap { try? JSONDecoder().decode([String: Row].self, from: $0) }) ?? [:]
         dirty = Set((UserDefaults.standard.array(forKey: Self.dirtyKey) as? [String]) ?? [])
         pruneOld()
+        recomputeCostTotals()
     }
 
     // MARK: - Recording
 
-    func recordTokens(_ tokens: Int, project: String?, agent: String) {
-        record(project: project, agent: agent, tokens: tokens, sessions: 0)
+    func recordTokens(_ tokens: Int, project: String?, agent: String, costUSD: Double = 0) {
+        record(project: project, agent: agent, tokens: tokens, sessions: 0, costUSD: costUSD)
     }
     func recordSession(project: String?, agent: String) {
         record(project: project, agent: agent, tokens: 0, sessions: 1)
     }
 
-    private func record(project: String?, agent: String, tokens: Int, sessions: Int) {
+    private func record(project: String?, agent: String, tokens: Int, sessions: Int, costUSD: Double = 0) {
         guard let project, !project.isEmpty, !agent.isEmpty, tokens > 0 || sessions > 0 else { return }
         let (pid, pname) = Self.projectIdentity(project)
         let day = Self.today()
@@ -47,10 +78,12 @@ final class ProjectUsageStore: ObservableObject {
         var r = rows[key] ?? Row(projectId: pid, projectName: pname, agent: agent, day: day, tokens: 0, sessions: 0)
         r.tokens += tokens
         r.sessions += sessions
+        r.costUSD += costUSD
         r.projectName = pname
         rows[key] = r
         dirty.insert(key)
         persist()
+        recomputeCostTotals()
         CareSyncController.shared.scheduleUsageSync()
     }
 
@@ -103,6 +136,14 @@ final class ProjectUsageStore: ObservableObject {
         guard !stale.isEmpty else { return }
         for k in stale { rows.removeValue(forKey: k); dirty.remove(k) }
         persist()
+        recomputeCostTotals()
+    }
+
+    private func recomputeCostTotals() {
+        let day = Self.today()
+        let month = String(day.prefix(7))
+        todayCostUSD = rows.values.filter { $0.day == day }.reduce(0) { $0 + $1.costUSD }
+        monthlyCostUSD = rows.values.filter { $0.day.hasPrefix(month) }.reduce(0) { $0 + $1.costUSD }
     }
     private static func dayString(daysAgo: Int) -> String {
         let d = Calendar.current.date(byAdding: .day, value: -daysAgo, to: Date()) ?? Date()

--- a/Tests/AgentPetAppTests/ProjectUsageStoreCostTests.swift
+++ b/Tests/AgentPetAppTests/ProjectUsageStoreCostTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+@testable import agentpet
+
+@MainActor
+final class ProjectUsageStoreCostTests: XCTestCase {
+    private let storageKey = "agentpet.projectUsage"
+    private let dirtyKey = "agentpet.projectUsage.dirty"
+
+    private var savedStorage: Any?
+    private var savedDirty: Any?
+
+    override func setUp() {
+        super.setUp()
+        savedStorage = UserDefaults.standard.object(forKey: storageKey)
+        savedDirty = UserDefaults.standard.object(forKey: dirtyKey)
+        UserDefaults.standard.removeObject(forKey: storageKey)
+        UserDefaults.standard.removeObject(forKey: dirtyKey)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: storageKey)
+        UserDefaults.standard.removeObject(forKey: dirtyKey)
+        if let savedStorage { UserDefaults.standard.set(savedStorage, forKey: storageKey) }
+        if let savedDirty { UserDefaults.standard.set(savedDirty, forKey: dirtyKey) }
+        savedStorage = nil
+        savedDirty = nil
+        super.tearDown()
+    }
+
+    // a) Backward-compat decode: old JSON without costUSD must still decode, defaulting to 0.
+    func testRowDecodesOldFormatWithoutCostUSD() throws {
+        let json = """
+        {"projectId":"p1","projectName":"test","agent":"claude","day":"2026-07-01","tokens":100,"sessions":1}
+        """
+        let data = Data(json.utf8)
+        let row = try JSONDecoder().decode(ProjectUsageStore.Row.self, from: data)
+        XCTAssertEqual(row.costUSD, 0)
+        XCTAssertEqual(row.tokens, 100)
+    }
+
+    // b) Forward decode: JSON with costUSD present decodes correctly.
+    func testRowDecodesNewFormatWithCostUSD() throws {
+        let json = """
+        {"projectId":"p1","projectName":"test","agent":"claude","day":"2026-07-01","tokens":100,"sessions":1,"costUSD":1.5}
+        """
+        let data = Data(json.utf8)
+        let row = try JSONDecoder().decode(ProjectUsageStore.Row.self, from: data)
+        XCTAssertEqual(row.costUSD, 1.5)
+    }
+
+    // c) recordTokens with cost accumulates correctly across multiple calls.
+    func testRecordTokensAccumulatesCost() {
+        let store = ProjectUsageStore()
+        store.recordTokens(1000, project: "/some/project", agent: "claude", costUSD: 0.05)
+        store.recordTokens(1000, project: "/some/project", agent: "claude", costUSD: 0.05)
+
+        let row = store.pendingRows().first { $0.agent == "claude" }
+        XCTAssertNotNil(row)
+        XCTAssertEqual(row?.tokens, 2000)
+        XCTAssertEqual(row?.costUSD ?? -1, 0.10, accuracy: 0.0001)
+    }
+
+    // d) recordTokens without cost arg defaults to 0, keeping existing call sites intact.
+    func testRecordTokensWithoutCostDefaultsToZero() {
+        let store = ProjectUsageStore()
+        store.recordTokens(500, project: "/p", agent: "claude")
+
+        let row = store.pendingRows().first { $0.agent == "claude" }
+        XCTAssertNotNil(row)
+        XCTAssertEqual(row?.costUSD, 0)
+    }
+
+    // e) todayCostUSD sums today's rows across projects/agents.
+    func testTodayCostUSDSumsAcrossProjects() {
+        let store = ProjectUsageStore()
+        store.recordTokens(1000, project: "/project/one", agent: "claude", costUSD: 0.10)
+        store.recordTokens(2000, project: "/project/two", agent: "codex", costUSD: 0.20)
+
+        XCTAssertEqual(store.todayCostUSD, 0.30, accuracy: 0.0001)
+    }
+
+    // f) monthlyCostUSD is at least todayCostUSD, and both are non-negative.
+    func testMonthlyCostUSDIsAtLeastTodayCostUSD() {
+        let store = ProjectUsageStore()
+        store.recordTokens(1000, project: "/project/one", agent: "claude", costUSD: 0.10)
+
+        XCTAssertGreaterThanOrEqual(store.monthlyCostUSD, store.todayCostUSD)
+        XCTAssertGreaterThanOrEqual(store.todayCostUSD, 0)
+        XCTAssertGreaterThanOrEqual(store.monthlyCostUSD, 0)
+    }
+}

--- a/Tests/AgentPetAppTests/ProjectUsageStoreCostTests.swift
+++ b/Tests/AgentPetAppTests/ProjectUsageStoreCostTests.swift
@@ -6,8 +6,8 @@ final class ProjectUsageStoreCostTests: XCTestCase {
     private let storageKey = "agentpet.projectUsage"
     private let dirtyKey = "agentpet.projectUsage.dirty"
 
-    private var savedStorage: Any?
-    private var savedDirty: Any?
+    nonisolated(unsafe) private var savedStorage: Any?
+    nonisolated(unsafe) private var savedDirty: Any?
 
     override func setUp() {
         super.setUp()

--- a/Tests/AgentPetCoreTests/ModelPricingTests.swift
+++ b/Tests/AgentPetCoreTests/ModelPricingTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+@testable import AgentPetCore
+
+final class ModelPricingTests: XCTestCase {
+
+    func testSonnetPricingWithAllFourTokenKinds() {
+        // sonnet: input $3.00/M, output $15.00/M
+        let cost = ModelPricing.costUSD(
+            model: "claude-sonnet-4-6-20260115",
+            inputTokens: 1_000,
+            outputTokens: 250,
+            cacheCreateTokens: 500,
+            cacheReadTokens: 2_000
+        )
+        let inputRate = 3.00
+        let outputRate = 15.00
+        let expected = (1_000 * inputRate
+            + 250 * outputRate
+            + 500 * inputRate * 1.25
+            + 2_000 * inputRate * 0.1) / 1_000_000
+        XCTAssertEqual(cost, expected, accuracy: 0.0000001)
+    }
+
+    func testOpusPricing() {
+        let cost = ModelPricing.costUSD(
+            model: "claude-opus-4-1",
+            inputTokens: 1_000,
+            outputTokens: 500,
+            cacheCreateTokens: 0,
+            cacheReadTokens: 0
+        )
+        let inputRate = 15.00
+        let outputRate = 75.00
+        let expected = (1_000 * inputRate + 500 * outputRate) / 1_000_000
+        XCTAssertEqual(cost, expected, accuracy: 0.0000001)
+    }
+
+    func testHaikuPricing() {
+        let cost = ModelPricing.costUSD(
+            model: "claude-haiku-3-5",
+            inputTokens: 2_000,
+            outputTokens: 1_000,
+            cacheCreateTokens: 0,
+            cacheReadTokens: 0
+        )
+        let inputRate = 1.00
+        let outputRate = 5.00
+        let expected = (2_000 * inputRate + 1_000 * outputRate) / 1_000_000
+        XCTAssertEqual(cost, expected, accuracy: 0.0000001)
+    }
+
+    func testUnknownModelFallsBackToSonnetRate() {
+        let cost = ModelPricing.costUSD(
+            model: "some-unrecognized-model-xyz",
+            inputTokens: 1_000,
+            outputTokens: 1_000,
+            cacheCreateTokens: 0,
+            cacheReadTokens: 0
+        )
+        let expected = (1_000 * 3.00 + 1_000 * 15.00) / 1_000_000
+        XCTAssertEqual(cost, expected, accuracy: 0.0000001)
+    }
+
+    func testNilModelFallsBackToSonnetRate() {
+        let cost = ModelPricing.costUSD(
+            model: nil,
+            inputTokens: 1_000,
+            outputTokens: 1_000,
+            cacheCreateTokens: 0,
+            cacheReadTokens: 0
+        )
+        let expected = (1_000 * 3.00 + 1_000 * 15.00) / 1_000_000
+        XCTAssertEqual(cost, expected, accuracy: 0.0000001)
+    }
+
+    func testAllZeroTokensReturnsZero() {
+        let cost = ModelPricing.costUSD(
+            model: "claude-sonnet-4-6-20260115",
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheCreateTokens: 0,
+            cacheReadTokens: 0
+        )
+        XCTAssertEqual(cost, 0, accuracy: 0.0000001)
+    }
+
+    func testFullModelIdMatchesSonnetTierViaSubstring() {
+        let cost = ModelPricing.costUSD(
+            model: "claude-sonnet-4-6-20260115",
+            inputTokens: 1_000,
+            outputTokens: 1_000,
+            cacheCreateTokens: 0,
+            cacheReadTokens: 0
+        )
+        let expected = (1_000 * 3.00 + 1_000 * 15.00) / 1_000_000
+        XCTAssertEqual(cost, expected, accuracy: 0.0000001)
+    }
+}

--- a/Tests/AgentPetCoreTests/TranscriptCostTests.swift
+++ b/Tests/AgentPetCoreTests/TranscriptCostTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import AgentPetCore
+
+final class TranscriptCostTests: XCTestCase {
+
+    private var path: String!
+
+    override func setUp() {
+        super.setUp()
+        path = NSTemporaryDirectory() + "agentpet-cost-\(UUID().uuidString).jsonl"
+        TranscriptReader.clearCache()
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(atPath: path)
+        super.tearDown()
+    }
+
+    private func append(_ lines: [String]) {
+        let data = (lines.joined(separator: "\n") + "\n").data(using: .utf8)!
+        if let handle = FileHandle(forWritingAtPath: path) {
+            defer { try? handle.close() }
+            _ = try? handle.seekToEnd()
+            handle.write(data)
+        } else {
+            try? data.write(to: URL(fileURLWithPath: path))
+        }
+    }
+
+    private func assistantLine(
+        input: Int,
+        output: Int,
+        cacheCreate: Int = 0,
+        cacheRead: Int = 0,
+        model: String = "claude-sonnet-4-6-20260115"
+    ) -> String {
+        #"{"type":"assistant","message":{"model":"\#(model)","usage":{"input_tokens":\#(input),"output_tokens":\#(output),"cache_creation_input_tokens":\#(cacheCreate),"cache_read_input_tokens":\#(cacheRead)},"content":[{"type":"text","text":"hi"}]}}"#
+    }
+
+    func testDeltaMatchesHandComputedFormula() {
+        append([
+            assistantLine(input: 1_000, output: 250, cacheCreate: 500, cacheRead: 2_000, model: "claude-sonnet-4-6-20260115"),
+        ])
+        let delta = TranscriptReader.newUsageDelta(at: path)
+
+        // sonnet: input $3.00/M, output $15.00/M, cache-create = inputRate*1.25, cache-read = inputRate*0.1
+        let expectedCost = (1_000.0 * 3.00
+            + 250.0 * 15.00
+            + 500.0 * 3.00 * 1.25
+            + 2_000.0 * 3.00 * 0.1) / 1_000_000.0
+
+        XCTAssertNotNil(delta)
+        XCTAssertEqual(delta?.tokens, 1_250)
+        XCTAssertEqual(delta?.costUSD ?? -1, expectedCost, accuracy: 0.0000001)
+    }
+
+    func testSecondCallWithNoNewLinesReturnsZeroDelta() {
+        append([assistantLine(input: 500, output: 100)])
+        _ = TranscriptReader.newUsageDelta(at: path)
+
+        let secondDelta = TranscriptReader.newUsageDelta(at: path)
+
+        XCTAssertEqual(secondDelta, TranscriptReader.UsageDelta(tokens: 0, costUSD: 0))
+    }
+
+    func testSumsTokensAndCostAcrossLinesWithDifferentModels() {
+        append([
+            assistantLine(input: 1_000, output: 500, model: "claude-opus-4-1"),
+            assistantLine(input: 2_000, output: 1_000, model: "claude-sonnet-4-6-20260115"),
+        ])
+        let delta = TranscriptReader.newUsageDelta(at: path)
+
+        let opusCost = (1_000.0 * 15.00 + 500.0 * 75.00) / 1_000_000.0
+        let sonnetCost = (2_000.0 * 3.00 + 1_000.0 * 15.00) / 1_000_000.0
+        let expectedCost = opusCost + sonnetCost
+        let expectedTokens = (1_000 + 500) + (2_000 + 1_000)
+
+        XCTAssertNotNil(delta)
+        XCTAssertEqual(delta?.tokens, expectedTokens)
+        XCTAssertEqual(delta?.costUSD ?? -1, expectedCost, accuracy: 0.0000001)
+    }
+
+    func testNewUsageDeltaForUnreadPathReturnsNil() {
+        let neverSeenPath = "/some/path/never/read/before-\(UUID().uuidString).jsonl"
+        XCTAssertNil(TranscriptReader.newUsageDelta(at: neverSeenPath))
+    }
+
+    func testClearCacheResetsByteOffsetSoDeltaIsRecomputedFromStart() {
+        append([assistantLine(input: 1_000, output: 250, model: "claude-sonnet-4-6-20260115")])
+        let firstDelta = TranscriptReader.newUsageDelta(at: path)
+
+        XCTAssertNotNil(firstDelta)
+        XCTAssertNotEqual(firstDelta?.tokens, 0)
+        XCTAssertNotEqual(firstDelta?.costUSD, 0)
+
+        TranscriptReader.clearCache()
+
+        let secondDelta = TranscriptReader.newUsageDelta(at: path)
+
+        XCTAssertEqual(secondDelta?.tokens, firstDelta?.tokens)
+        XCTAssertEqual(secondDelta?.costUSD ?? -1, firstDelta?.costUSD ?? -2, accuracy: 0.0000001)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a local-only estimated USD cost display (today / this month) alongside the existing token-usage stats
- New `ModelPricing` estimates cost per Claude model tier (haiku/opus/sonnet) from token counts, since hook payloads don't carry Claude Code's own cost figures (that's statusline-input-only)
- `TranscriptReader` gains an atomic `newUsageDelta(at:)` that returns token count + cost together in one lock-protected call, avoiding a race between concurrent background reads of the same transcript
- `ProjectUsageStore` gains a `costUSD` ledger with a backward-compatible decoder, so existing users' persisted usage history isn't lost on upgrade
- UI label reads "Est. cost (Claude)" — Codex usage isn't priced yet (no pricing table), called out explicitly to avoid confusion with the combined token count shown elsewhere

## Test plan
- [x] `swift build` — 0 errors
- [x] `swift test` — 326 tests, 0 failures (existing `TranscriptUsageTests` untouched/unchanged)
- [x] Independent code review pass (flagged and fixed one race-condition issue before this PR)