### PR TITLE
feat: approve/deny Claude Code Bash permission requests directly from the pet bubble (opt-in)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ landing/node_modules/
 
 # Claude Code local tooling
 .claude/
+.aurora-cli/

--- a/Sources/AgentPetCore/AgentEvent.swift
+++ b/Sources/AgentPetCore/AgentEvent.swift
@@ -17,6 +17,15 @@ public struct AgentEvent: Codable, Sendable, Equatable {
     public var transcriptPath: String?
     /// Subagent identifier from a `SubagentStop` event (e.g. `"agent-abc123"`).
     public var subagentId: String?
+    /// Non-nil marks this event as a gated `PreToolUse` request: the daemon
+    /// is holding the hook's connection open until the user approves/denies.
+    public var approvalRequestId: String?
+    /// Name of the tool awaiting approval (e.g. `"Bash"`). Set alongside
+    /// `approvalRequestId`.
+    public var toolName: String?
+    /// Human-readable summary of the pending tool call (e.g. the shell
+    /// command), truncated for display. Set alongside `approvalRequestId`.
+    public var toolSummary: String?
     public var timestamp: Date
 
     public init(
@@ -28,6 +37,9 @@ public struct AgentEvent: Codable, Sendable, Equatable {
         model: String? = nil,
         transcriptPath: String? = nil,
         subagentId: String? = nil,
+        approvalRequestId: String? = nil,
+        toolName: String? = nil,
+        toolSummary: String? = nil,
         timestamp: Date
     ) {
         self.sessionId = sessionId
@@ -38,6 +50,9 @@ public struct AgentEvent: Codable, Sendable, Equatable {
         self.model = model
         self.transcriptPath = transcriptPath
         self.subagentId = subagentId
+        self.approvalRequestId = approvalRequestId
+        self.toolName = toolName
+        self.toolSummary = toolSummary
         self.timestamp = timestamp
     }
 }

--- a/Sources/AgentPetCore/AgentSession.swift
+++ b/Sources/AgentPetCore/AgentSession.swift
@@ -1,5 +1,18 @@
 import Foundation
 
+/// A gated tool call awaiting the user's allow/deny decision.
+public struct PendingApproval: Sendable, Equatable {
+    public let requestId: String
+    public let toolName: String
+    public let summary: String
+
+    public init(requestId: String, toolName: String, summary: String) {
+        self.requestId = requestId
+        self.toolName = toolName
+        self.summary = summary
+    }
+}
+
 /// Current known state of one agent session.
 public struct AgentSession: Identifiable, Sendable, Equatable {
     public let id: String
@@ -20,6 +33,8 @@ public struct AgentSession: Identifiable, Sendable, Equatable {
     public var stateSince: Date
     /// When the session was first created (first `apply` event).
     public var createdAt: Date
+    /// Gated tool call currently awaiting the user's decision, if any.
+    public var pendingApproval: PendingApproval?
 
     public init(
         id: String,
@@ -32,7 +47,8 @@ public struct AgentSession: Identifiable, Sendable, Equatable {
         source: AgentSource,
         updatedAt: Date,
         stateSince: Date? = nil,
-        createdAt: Date? = nil
+        createdAt: Date? = nil,
+        pendingApproval: PendingApproval? = nil
     ) {
         self.id = id
         self.agentKind = agentKind
@@ -45,5 +61,6 @@ public struct AgentSession: Identifiable, Sendable, Equatable {
         self.updatedAt = updatedAt
         self.stateSince = stateSince ?? updatedAt
         self.createdAt = createdAt ?? updatedAt
+        self.pendingApproval = pendingApproval
     }
 }

--- a/Sources/AgentPetCore/ApprovalGateConfig.swift
+++ b/Sources/AgentPetCore/ApprovalGateConfig.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Opt-in whitelist for the bubble approval gate: the gate stays OFF unless
+/// `~/.agentpet/approval-gate.json` exists with `{"tools": ["Bash", ...]}`.
+public enum ApprovalGateConfig {
+    public static var defaultPath: String {
+        (AgentPetPaths.baseDir as NSString).appendingPathComponent("approval-gate.json")
+    }
+
+    /// Tools whose `PreToolUse` gates the session on a user decision.
+    /// Missing or unreadable config means the feature is disabled.
+    public static func gatedTools(path: String? = nil) -> Set<String> {
+        let file = path ?? defaultPath
+        guard let data = FileManager.default.contents(atPath: file),
+              let config = try? JSONDecoder().decode(Config.self, from: data) else { return [] }
+        return Set(config.tools)
+    }
+
+    private struct Config: Decodable {
+        let tools: [String]
+    }
+}

--- a/Sources/AgentPetCore/ClaudeHookPayload.swift
+++ b/Sources/AgentPetCore/ClaudeHookPayload.swift
@@ -27,6 +27,9 @@ public struct ClaudeHookPayload: Decodable, Equatable {
         case agentId = "agent_id"
     }
 
+    /// Tools whose `PreToolUse` event gates the session on a user decision.
+    private static let gatedTools: Set<String> = ["Bash"]
+
     public static func decode(from data: Data) -> ClaudeHookPayload? {
         try? JSONDecoder().decode(ClaudeHookPayload.self, from: data)
     }
@@ -42,10 +45,22 @@ public struct ClaudeHookPayload: Decodable, Equatable {
             toolInput: toolInput,
             explicitMessage: message
         ) ?? toolName.map { "Using \($0)" }
+
+        var approvalRequestId: String?
+        var approvalToolName: String?
+        var approvalToolSummary: String?
+        if kind == .claude, hookEventName == "PreToolUse", let toolName, Self.gatedTools.contains(toolName) {
+            approvalRequestId = UUID().uuidString
+            approvalToolName = toolName
+            approvalToolSummary = String((toolInput?.command ?? toolName).prefix(80))
+        }
+
         return AgentEvent(
             sessionId: sessionId, agentKind: kind, eventName: hookEventName,
             project: cwd, message: context, model: model?.displayName,
-            transcriptPath: transcriptPath, subagentId: agentId, timestamp: now
+            transcriptPath: transcriptPath, subagentId: agentId,
+            approvalRequestId: approvalRequestId, toolName: approvalToolName,
+            toolSummary: approvalToolSummary, timestamp: now
         )
     }
 }

--- a/Sources/AgentPetCore/ClaudeHookPayload.swift
+++ b/Sources/AgentPetCore/ClaudeHookPayload.swift
@@ -27,16 +27,16 @@ public struct ClaudeHookPayload: Decodable, Equatable {
         case agentId = "agent_id"
     }
 
-    /// Tools whose `PreToolUse` event gates the session on a user decision.
-    private static let gatedTools: Set<String> = ["Bash"]
-
     public static func decode(from data: Data) -> ClaudeHookPayload? {
         try? JSONDecoder().decode(ClaudeHookPayload.self, from: data)
     }
 
-    /// Builds an `AgentEvent` from the payload, or `nil` if the essential
-    /// fields (session id and event name) are missing.
-    public func makeEvent(now: Date, kind: AgentKind = .claude) -> AgentEvent? {
+    /// Builds an `AgentEvent`, or `nil` if session id / event name are missing.
+    /// `gatedTools` defaults to the opt-in config — empty means the gate is off.
+    public func makeEvent(
+        now: Date, kind: AgentKind = .claude,
+        gatedTools: Set<String> = ApprovalGateConfig.gatedTools()
+    ) -> AgentEvent? {
         guard let sessionId, let hookEventName else { return nil }
         let context = ActivityFormatter.activityMessage(
             eventName: hookEventName,
@@ -49,7 +49,7 @@ public struct ClaudeHookPayload: Decodable, Equatable {
         var approvalRequestId: String?
         var approvalToolName: String?
         var approvalToolSummary: String?
-        if kind == .claude, hookEventName == "PreToolUse", let toolName, Self.gatedTools.contains(toolName) {
+        if kind == .claude, hookEventName == "PreToolUse", let toolName, gatedTools.contains(toolName) {
             approvalRequestId = UUID().uuidString
             approvalToolName = toolName
             approvalToolSummary = String((toolInput?.command ?? toolName).prefix(80))

--- a/Sources/AgentPetCore/EventSender.swift
+++ b/Sources/AgentPetCore/EventSender.swift
@@ -21,15 +21,61 @@ public enum EventSender {
     }
 
     static func writeToSocket(_ data: Data, path: String) -> Bool {
-        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
-        guard fd >= 0 else { return false }
+        guard let fd = connectedSocket(path: path) else { return false }
         defer { close(fd) }
+        return writeAll(data, fd: fd)
+    }
+
+    static func writeToQueue(_ data: Data, dir: String) {
+        let fm = FileManager.default
+        try? fm.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        let name = "\(Int(Date().timeIntervalSince1970))-\(UUID().uuidString).json"
+        let full = (dir as NSString).appendingPathComponent(name)
+        try? data.write(to: URL(fileURLWithPath: full))
+    }
+
+    /// Sends an approval-gated event and blocks for the daemon's decision,
+    /// falling back to `.ask` on connect/write/timeout/decode failure.
+    public static func sendAndAwaitReply(
+        _ event: AgentEvent, socketPath: String, timeout: TimeInterval = 25
+    ) -> ApprovalDecision {
+        guard let line = try? encodeLine(event), let fd = connectedSocket(path: socketPath) else {
+            return .ask
+        }
+        defer { close(fd) }
+        guard writeAll(line, fd: fd) else { return .ask }
+
+        var tv = timeval(
+            tv_sec: Int(timeout), tv_usec: Int32(timeout.truncatingRemainder(dividingBy: 1) * 1_000_000)
+        )
+        guard setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, socklen_t(MemoryLayout<timeval>.size)) == 0 else {
+            return .ask
+        }
+
+        let deadline = Date().addingTimeInterval(timeout)
+        var buffer = Data()
+        var chunk = [UInt8](repeating: 0, count: 256)
+        while !buffer.contains(0x0A) {
+            guard Date() < deadline else { return .ask }
+            let n = read(fd, &chunk, chunk.count)
+            if n <= 0 { return .ask }
+            buffer.append(contentsOf: chunk[0..<n])
+        }
+        guard let newlineIndex = buffer.firstIndex(of: 0x0A),
+              let reply = try? EventCoding.decoder.decode(ApprovalReply.self, from: Data(buffer[..<newlineIndex]))
+        else { return .ask }
+        return reply.decision
+    }
+
+    private static func connectedSocket(path: String) -> Int32? {
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return nil }
 
         var addr = sockaddr_un()
         addr.sun_family = sa_family_t(AF_UNIX)
         let bytes = Array(path.utf8)
         let capacity = MemoryLayout.size(ofValue: addr.sun_path)
-        guard bytes.count < capacity else { return false }
+        guard bytes.count < capacity else { close(fd); return nil }
         withUnsafeMutablePointer(to: &addr.sun_path) { tuplePtr in
             tuplePtr.withMemoryRebound(to: CChar.self, capacity: capacity) { dst in
                 for (i, b) in bytes.enumerated() { dst[i] = CChar(bitPattern: b) }
@@ -40,9 +86,12 @@ public enum EventSender {
         let connected = withUnsafePointer(to: &addr) { ptr in
             ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { connect(fd, $0, size) }
         }
-        guard connected == 0 else { return false }
+        guard connected == 0 else { close(fd); return nil }
+        return fd
+    }
 
-        return data.withUnsafeBytes { raw -> Bool in
+    static func writeAll(_ data: Data, fd: Int32) -> Bool {
+        data.withUnsafeBytes { raw -> Bool in
             var offset = 0
             while offset < raw.count {
                 let n = write(fd, raw.baseAddress!.advanced(by: offset), raw.count - offset)
@@ -52,12 +101,8 @@ public enum EventSender {
             return true
         }
     }
+}
 
-    static func writeToQueue(_ data: Data, dir: String) {
-        let fm = FileManager.default
-        try? fm.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        let name = "\(Int(Date().timeIntervalSince1970))-\(UUID().uuidString).json"
-        let full = (dir as NSString).appendingPathComponent(name)
-        try? data.write(to: URL(fileURLWithPath: full))
-    }
+private struct ApprovalReply: Decodable {
+    let decision: ApprovalDecision
 }

--- a/Sources/AgentPetCore/EventSender.swift
+++ b/Sources/AgentPetCore/EventSender.swift
@@ -37,7 +37,7 @@ public enum EventSender {
     /// Sends an approval-gated event and blocks for the daemon's decision,
     /// falling back to `.ask` on connect/write/timeout/decode failure.
     public static func sendAndAwaitReply(
-        _ event: AgentEvent, socketPath: String, timeout: TimeInterval = 25
+        _ event: AgentEvent, socketPath: String, timeout: TimeInterval = 12
     ) -> ApprovalDecision {
         guard let line = try? encodeLine(event), let fd = connectedSocket(path: socketPath) else {
             return .ask
@@ -87,6 +87,9 @@ public enum EventSender {
             ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { connect(fd, $0, size) }
         }
         guard connected == 0 else { close(fd); return nil }
+        // SO_NOSIGPIPE: a write after the daemon died must not SIGPIPE the CLI.
+        var on: Int32 = 1
+        _ = setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &on, socklen_t(MemoryLayout<Int32>.size))
         return fd
     }
 

--- a/Sources/AgentPetCore/EventSocketServer.swift
+++ b/Sources/AgentPetCore/EventSocketServer.swift
@@ -116,16 +116,34 @@ public final class EventSocketServer: @unchecked Sendable {
         }
     }
 
+    // Assumes one event per connection: if the first line decodes to an
+    // approval request, its fd is handed off to the registry (not closed here).
     private func handleClient(_ fd: Int32, onEvent: (AgentEvent) -> Void) {
-        defer { close(fd) }
         var buffer = Data()
         var chunk = [UInt8](repeating: 0, count: 4096)
-        while true {
-            let n = read(fd, &chunk, chunk.count)
-            if n <= 0 { break }
-            buffer.append(contentsOf: chunk[0..<n])
+        while buffer.firstIndex(of: 0x0A) == nil {
+            guard Self.readMore(fd: fd, into: &buffer, chunk: &chunk) else { break }
         }
+        if let newlineIndex = buffer.firstIndex(of: 0x0A) {
+            let line = buffer[..<newlineIndex]
+            if let event = try? EventCoding.decoder.decode(AgentEvent.self, from: Data(line)),
+               let requestId = event.approvalRequestId {
+                PendingApprovalRegistry.shared.register(requestId: requestId, fd: fd)
+                onEvent(event)
+                return
+            }
+        }
+        while Self.readMore(fd: fd, into: &buffer, chunk: &chunk) {}
+        close(fd)
         Self.decodeLines(buffer, onEvent: onEvent)
+    }
+
+    /// Reads one chunk from `fd` into `buffer`. Returns `false` at EOF/error.
+    private static func readMore(fd: Int32, into buffer: inout Data, chunk: inout [UInt8]) -> Bool {
+        let n = read(fd, &chunk, chunk.count)
+        guard n > 0 else { return false }
+        buffer.append(contentsOf: chunk[0..<n])
+        return true
     }
 
     /// Drains a directory of queued event files written while the daemon was

--- a/Sources/AgentPetCore/PendingApprovalRegistry.swift
+++ b/Sources/AgentPetCore/PendingApprovalRegistry.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// The user's decision for a gated tool call, written back to the CLI hook.
+public enum ApprovalDecision: String, Codable, Sendable {
+    case allow, deny, ask
+}
+
+/// Builds the Claude Code hook JSON that carries a `PreToolUse` permission decision.
+public enum ApprovalHookResponse {
+    public static func json(for decision: ApprovalDecision) -> String {
+        "{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"\(decision.rawValue)\"}}"
+    }
+}
+
+/// Tracks CLI hook connections (file descriptors) awaiting an approval
+/// decision, keyed by request id, and writes the decision back when resolved.
+
+// Known limitation (a): a timeout only resolves the CLI-side fd; it does not
+// notify `SessionStore`, so the UI's pending approval clears on the next event.
+
+// Known limitation (b): a decision after the timeout fires returns `false`
+// from `resolve`, but the UI still clears — the timeout already decided.
+public final class PendingApprovalRegistry: @unchecked Sendable {
+    public static let shared = PendingApprovalRegistry()
+
+    private let queue = DispatchQueue(label: "com.agentpet.pendingApprovalRegistry")
+    private var fds: [String: Int32] = [:]
+
+    public init() {}
+
+    /// Registers `fd` for `requestId`, auto-resolving to `.ask` after
+    /// `timeout` seconds if no manual `resolve` call arrives first.
+    public func register(requestId: String, fd: Int32, timeout: TimeInterval = 25) {
+        queue.async { self.fds[requestId] = fd }
+        queue.asyncAfter(deadline: .now() + timeout) { [self] in
+            _resolveLocked(requestId: requestId, decision: .ask)
+        }
+    }
+
+    /// Writes the decision to the registered fd and closes it. Returns
+    /// `false` (no-op) if `requestId` isn't registered (already resolved).
+    @discardableResult
+    public func resolve(requestId: String, decision: ApprovalDecision) -> Bool {
+        queue.sync { _resolveLocked(requestId: requestId, decision: decision) }
+    }
+
+    // Must only be called on `queue`.
+    @discardableResult
+    private func _resolveLocked(requestId: String, decision: ApprovalDecision) -> Bool {
+        guard let fd = fds.removeValue(forKey: requestId) else { return false }
+        let data = Data("{\"decision\":\"\(decision.rawValue)\"}\n".utf8)
+        _ = EventSender.writeAll(data, fd: fd)
+        close(fd)
+        return true
+    }
+}

--- a/Sources/AgentPetCore/PendingApprovalRegistry.swift
+++ b/Sources/AgentPetCore/PendingApprovalRegistry.swift
@@ -28,9 +28,12 @@ public final class PendingApprovalRegistry: @unchecked Sendable {
 
     public init() {}
 
-    /// Registers `fd` for `requestId`, auto-resolving to `.ask` after
-    /// `timeout` seconds if no manual `resolve` call arrives first.
-    public func register(requestId: String, fd: Int32, timeout: TimeInterval = 25) {
+    /// Auto-resolves to `.ask` after `timeout` — kept shorter than the CLI's
+    /// read timeout so the reply lands while the peer is still reading.
+    public func register(requestId: String, fd: Int32, timeout: TimeInterval = 10) {
+        // SO_NOSIGPIPE: a write after the CLI died must not SIGPIPE the daemon.
+        var on: Int32 = 1
+        _ = setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &on, socklen_t(MemoryLayout<Int32>.size))
         queue.async { self.fds[requestId] = fd }
         queue.asyncAfter(deadline: .now() + timeout) { [self] in
             _resolveLocked(requestId: requestId, decision: .ask)

--- a/Sources/AgentPetCore/SessionStore.swift
+++ b/Sources/AgentPetCore/SessionStore.swift
@@ -86,8 +86,18 @@ public final class SessionStore {
             byID.removeValue(forKey: event.sessionId)
             return nil
         }
-        guard let state = StateMapper.state(for: event.agentKind, eventName: event.eventName) else {
+        guard var state = StateMapper.state(for: event.agentKind, eventName: event.eventName) else {
             return nil
+        }
+
+        let pendingApproval: PendingApproval?
+        if let requestId = event.approvalRequestId {
+            state = .waiting
+            pendingApproval = PendingApproval(
+                requestId: requestId, toolName: event.toolName ?? "", summary: event.toolSummary ?? ""
+            )
+        } else {
+            pendingApproval = nil
         }
 
         if var existing = byID[event.sessionId] {
@@ -97,6 +107,7 @@ public final class SessionStore {
             if let project = event.project { existing.project = project }
             if let model = event.model { existing.model = model }
             existing.message = event.message
+            existing.pendingApproval = pendingApproval
             byID[event.sessionId] = existing
             return existing
         }
@@ -108,10 +119,22 @@ public final class SessionStore {
             message: event.message,
             model: event.model,
             source: .hook,
-            updatedAt: now
+            updatedAt: now,
+            pendingApproval: pendingApproval
         )
         byID[event.sessionId] = session
         return session
+    }
+
+    /// Clears the pending approval for `id` and moves it to `.working`, but
+    /// only if `requestId` matches; otherwise a no-op returning `false`.
+    @discardableResult
+    public func resolveApproval(id: String, requestId: String) -> Bool {
+        guard var session = byID[id], session.pendingApproval?.requestId == requestId else { return false }
+        session.pendingApproval = nil
+        session.state = .working
+        byID[id] = session
+        return true
     }
 
     /// Demotes stale `done` sessions to `idle`, removes long-idle ones, and

--- a/Sources/App/AppDaemon.swift
+++ b/Sources/App/AppDaemon.swift
@@ -21,6 +21,9 @@ final class AppDaemon: ObservableObject {
     private var pruneTimer: Timer?
 
     func start() {
+        // The approval reply can race the CLI closing its socket — a stray
+        // write must return EPIPE, not SIGPIPE-kill the whole app.
+        signal(SIGPIPE, SIG_IGN)
         try? FileManager.default.createDirectory(
             atPath: AgentPetPaths.baseDir, withIntermediateDirectories: true
         )

--- a/Sources/App/AppDaemon.swift
+++ b/Sources/App/AppDaemon.swift
@@ -56,6 +56,15 @@ final class AppDaemon: ObservableObject {
         refresh()
     }
 
+    /// Resolves a pending approval from the bubble UI: writes the decision to
+    /// the hook and optimistically clears the pending state in the store.
+    func resolveApproval(sessionId: String, requestId: String, decision: ApprovalDecision) {
+        _ = PendingApprovalRegistry.shared.resolve(requestId: requestId, decision: decision)
+        if store.resolveApproval(id: sessionId, requestId: requestId) {
+            refresh()
+        }
+    }
+
     private func ingest(_ event: AgentEvent) {
         let before = store.session(id: event.sessionId)?.state
         guard let updated = store.apply(event, now: Date()) else {

--- a/Sources/App/CLI.swift
+++ b/Sources/App/CLI.swift
@@ -19,6 +19,13 @@ enum HookCLI {
             ))
             exit(2)
         }
+        // Approval-gated events must reply with the hook's permission decision on
+        // stdout so Claude Code can allow/deny the tool call synchronously.
+        if event.approvalRequestId != nil {
+            let decision = EventSender.sendAndAwaitReply(event, socketPath: AgentPetPaths.socketPath)
+            print(ApprovalHookResponse.json(for: decision))
+            exit(0)
+        }
         EventSender.send(event, socketPath: AgentPetPaths.socketPath, queueDir: AgentPetPaths.queueDir)
         exit(0)
     }

--- a/Sources/App/PetView.swift
+++ b/Sources/App/PetView.swift
@@ -716,10 +716,19 @@ private struct AgentRow: View {
     /// text too, so "waiting for input" reads as urgent at a glance.
     private static let waitingColor = Color(red: 0xF5 / 255.0, green: 0x9E / 255.0, blue: 0x0B / 255.0)
 
+    @ViewBuilder
     var body: some View {
+        if let pending = session.pendingApproval {
+            PendingApprovalRow(session: session, pending: pending, chatStyle: chatStyle)
+        } else {
+            rowBody
+        }
+    }
+
+    private var rowBody: some View {
         let visible = settings.effectiveLayout.tokens.filter { $0.isVisible && tokenHasValue($0.token) }
 
-        HStack(alignment: .center, spacing: 4) {
+        return HStack(alignment: .center, spacing: 4) {
             if visible.contains(where: { $0.token == .dot }) {
                 tokenView(for: .dot)
             }
@@ -895,6 +904,63 @@ private struct AgentRow: View {
         let m = s / 60
         if m < 60  { return "\(m)m" }
         return "\(m / 60)h \(m % 60)m"
+    }
+}
+
+// MARK: - Pending approval row
+
+/// Row shown instead of the normal status line when a session has a gated
+/// tool call awaiting the user's allow/deny decision.
+private struct PendingApprovalRow: View {
+    let session: AgentSession
+    let pending: PendingApproval
+    var chatStyle: Bool = false
+    @ObservedObject private var settings = BubbleSettings.shared
+
+    private static let waitingColor = Color(red: 0xF5 / 255.0, green: 0x9E / 255.0, blue: 0x0B / 255.0)
+    private static let allowColor = Color(red: 0.13, green: 0.77, blue: 0.37)
+    private static let denyColor = Color(red: 0.86, green: 0.23, blue: 0.23)
+
+    private var rowMaxWidth: CGFloat {
+        chatStyle ? AgentBubble.petContentMaxWidth : AgentBubble.contentMaxWidth
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 6) {
+            Circle().fill(Self.waitingColor).frame(width: 8, height: 8)
+            Text("\(pending.toolName): \(pending.summary)")
+                .font(.system(size: settings.fontSize.primaryPt, weight: .medium))
+                .foregroundStyle(textColor(0.82))
+                .lineLimit(1)
+                .truncationMode(.tail)
+            decisionButton(title: NSLocalizedString("Allow", comment: "Approve a pending tool call"),
+                            tint: Self.allowColor, decision: .allow)
+            decisionButton(title: NSLocalizedString("Deny", comment: "Reject a pending tool call"),
+                            tint: Self.denyColor, decision: .deny)
+        }
+        .frame(maxWidth: rowMaxWidth, alignment: .leading)
+    }
+
+    private func decisionButton(title: String, tint: Color, decision: ApprovalDecision) -> some View {
+        Button {
+            AppDaemon.shared.resolveApproval(sessionId: session.id, requestId: pending.requestId, decision: decision)
+        } label: {
+            Text(title)
+                .font(.system(size: settings.fontSize.secondaryPt, weight: .semibold))
+                .foregroundStyle(tint)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(Capsule().fill(tint.opacity(0.12)))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func textColor(_ opacity: Double) -> Color {
+        switch settings.theme {
+        case .light:  return .black.opacity(opacity)
+        case .dark:   return .white.opacity(opacity)
+        case .system: return Color.primary.opacity(opacity)
+        }
     }
 }
 

--- a/Tests/AgentPetCoreTests/AgentEventTests.swift
+++ b/Tests/AgentPetCoreTests/AgentEventTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import AgentPetCore
+
+final class AgentEventTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_000_000)
+
+    func testApprovalFieldsDefaultToNil() {
+        let event = AgentEvent(sessionId: "s1", agentKind: .claude, eventName: "Stop", timestamp: now)
+        XCTAssertNil(event.approvalRequestId)
+        XCTAssertNil(event.toolName)
+        XCTAssertNil(event.toolSummary)
+    }
+
+    func testCodableRoundTripPreservesApprovalFields() throws {
+        let event = AgentEvent(
+            sessionId: "s1", agentKind: .claude, eventName: "PreToolUse",
+            approvalRequestId: "req-1", toolName: "Bash", toolSummary: "npm test",
+            timestamp: now
+        )
+        let data = try EventCoding.encoder.encode(event)
+        let decoded = try EventCoding.decoder.decode(AgentEvent.self, from: data)
+        XCTAssertEqual(decoded, event)
+        XCTAssertEqual(decoded.approvalRequestId, "req-1")
+        XCTAssertEqual(decoded.toolName, "Bash")
+        XCTAssertEqual(decoded.toolSummary, "npm test")
+    }
+
+    func testCodableRoundTripWithNilApprovalFields() throws {
+        let event = AgentEvent(sessionId: "s1", agentKind: .claude, eventName: "Stop", timestamp: now)
+        let data = try EventCoding.encoder.encode(event)
+        let decoded = try EventCoding.decoder.decode(AgentEvent.self, from: data)
+        XCTAssertEqual(decoded, event)
+        XCTAssertNil(decoded.approvalRequestId)
+        XCTAssertNil(decoded.toolName)
+        XCTAssertNil(decoded.toolSummary)
+    }
+}

--- a/Tests/AgentPetCoreTests/ApprovalRoundTripTests.swift
+++ b/Tests/AgentPetCoreTests/ApprovalRoundTripTests.swift
@@ -1,0 +1,154 @@
+import XCTest
+@testable import AgentPetCore
+
+/// Phase 2 approve/deny round trip over the socket, plus the CLI hook's JSON helper.
+final class ApprovalRoundTripTests: XCTestCase {
+    private final class Box<T>: @unchecked Sendable {
+        var value: T?
+    }
+
+    private func makeApprovalEvent(requestId: String) -> AgentEvent {
+        AgentEvent(
+            sessionId: "s1", agentKind: .claude, eventName: "PreToolUse",
+            approvalRequestId: requestId, toolName: "Bash", toolSummary: "rm -rf /tmp/x",
+            timestamp: Date(timeIntervalSince1970: 1)
+        )
+    }
+
+    func testApproveRoundTrip() throws {
+        let path = "/tmp/agentpet-\(UUID().uuidString).sock"
+        let server = EventSocketServer(path: path)
+        defer { server.stop() }
+
+        let requestId = "req-approve-\(UUID().uuidString)"
+        let eventReceived = expectation(description: "onEvent invoked")
+        try server.start { event in
+            XCTAssertEqual(event.approvalRequestId, requestId)
+            PendingApprovalRegistry.shared.resolve(requestId: requestId, decision: .allow)
+            eventReceived.fulfill()
+        }
+
+        let event = makeApprovalEvent(requestId: requestId)
+        let resultBox = Box<ApprovalDecision>()
+        let replyReceived = expectation(description: "reply received")
+        DispatchQueue.global().async {
+            resultBox.value = EventSender.sendAndAwaitReply(event, socketPath: path, timeout: 5)
+            replyReceived.fulfill()
+        }
+
+        wait(for: [eventReceived, replyReceived], timeout: 5)
+        XCTAssertEqual(resultBox.value, .allow)
+    }
+
+    func testDenyRoundTrip() throws {
+        let path = "/tmp/agentpet-\(UUID().uuidString).sock"
+        let server = EventSocketServer(path: path)
+        defer { server.stop() }
+
+        let requestId = "req-deny-\(UUID().uuidString)"
+        let eventReceived = expectation(description: "onEvent invoked")
+        try server.start { event in
+            PendingApprovalRegistry.shared.resolve(requestId: requestId, decision: .deny)
+            eventReceived.fulfill()
+        }
+
+        let event = makeApprovalEvent(requestId: requestId)
+        let resultBox = Box<ApprovalDecision>()
+        let replyReceived = expectation(description: "reply received")
+        DispatchQueue.global().async {
+            resultBox.value = EventSender.sendAndAwaitReply(event, socketPath: path, timeout: 5)
+            replyReceived.fulfill()
+        }
+
+        wait(for: [eventReceived, replyReceived], timeout: 5)
+        XCTAssertEqual(resultBox.value, .deny)
+    }
+
+    func testTimeoutReturnsAskWithoutHanging() throws {
+        let path = "/tmp/agentpet-\(UUID().uuidString).sock"
+        let server = EventSocketServer(path: path)
+        defer { server.stop() }
+
+        let requestId = "req-timeout-\(UUID().uuidString)"
+        let eventReceived = expectation(description: "onEvent invoked")
+        // Deliberately never resolve this request; the client must time out on its own.
+        try server.start { _ in eventReceived.fulfill() }
+
+        let event = makeApprovalEvent(requestId: requestId)
+        let resultBox = Box<ApprovalDecision>()
+        let replyReceived = expectation(description: "reply received")
+        DispatchQueue.global().async {
+            resultBox.value = EventSender.sendAndAwaitReply(event, socketPath: path, timeout: 1)
+            replyReceived.fulfill()
+        }
+
+        wait(for: [eventReceived, replyReceived], timeout: 3)
+        XCTAssertEqual(resultBox.value, .ask)
+    }
+
+    func testNoDaemonReturnsAskImmediately() {
+        let path = "/tmp/agentpet-\(UUID().uuidString).sock" // nothing listening here
+        let start = Date()
+        let decision = EventSender.sendAndAwaitReply(
+            makeApprovalEvent(requestId: "req-no-daemon"), socketPath: path, timeout: 5
+        )
+        XCTAssertEqual(decision, .ask)
+        XCTAssertLessThan(Date().timeIntervalSince(start), 2, "connect failure must not wait for the timeout")
+    }
+
+    func testNonApprovalEventClosesConnectionAfterSend() throws {
+        let path = "/tmp/agentpet-\(UUID().uuidString).sock"
+        let server = EventSocketServer(path: path)
+        defer { server.stop() }
+
+        let eventReceived = expectation(description: "onEvent invoked")
+        let box = Box<AgentEvent>()
+        try server.start { event in
+            box.value = event
+            eventReceived.fulfill()
+        }
+
+        let event = AgentEvent(
+            sessionId: "s-plain", agentKind: .claude, eventName: "Stop",
+            timestamp: Date(timeIntervalSince1970: 42)
+        )
+        let dir = NSTemporaryDirectory() + "agentpet-q-\(UUID().uuidString)"
+        let delivered = EventSender.send(event, socketPath: path, queueDir: dir)
+
+        wait(for: [eventReceived], timeout: 5)
+        XCTAssertTrue(delivered, "socket path exists, must deliver over the socket (not fall back to queue)")
+        XCTAssertEqual(box.value?.approvalRequestId, nil)
+        XCTAssertEqual(box.value, event)
+    }
+
+    func testApprovalResponseJSONForAllow() throws {
+        try assertApprovalResponseJSON(.allow, expectedPermissionDecision: "allow")
+    }
+
+    func testApprovalResponseJSONForDeny() throws {
+        try assertApprovalResponseJSON(.deny, expectedPermissionDecision: "deny")
+    }
+
+    func testApprovalResponseJSONForAsk() throws {
+        try assertApprovalResponseJSON(.ask, expectedPermissionDecision: "ask")
+    }
+
+    private func assertApprovalResponseJSON(
+        _ decision: ApprovalDecision, expectedPermissionDecision: String,
+        file: StaticString = #filePath, line: UInt = #line
+    ) throws {
+        let json = ApprovalHookResponse.json(for: decision)
+        let data = try XCTUnwrap(json.data(using: .utf8), file: file, line: line)
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let hookSpecificOutput = try XCTUnwrap(
+            parsed?["hookSpecificOutput"] as? [String: Any], file: file, line: line
+        )
+        XCTAssertEqual(
+            hookSpecificOutput["hookEventName"] as? String, "PreToolUse", file: file, line: line
+        )
+        XCTAssertEqual(
+            hookSpecificOutput["permissionDecision"] as? String, expectedPermissionDecision,
+            file: file, line: line
+        )
+    }
+}

--- a/Tests/AgentPetCoreTests/ClaudeHookPayloadTests.swift
+++ b/Tests/AgentPetCoreTests/ClaudeHookPayloadTests.swift
@@ -86,4 +86,57 @@ final class ClaudeHookPayloadTests: XCTestCase {
         XCTAssertEqual(event?.agentKind, .gemini)
         XCTAssertTrue(ActivityTheme.chef.running.contains(event?.message ?? ""), "got \(event?.message ?? "nil")")
     }
+
+    // MARK: - approval gating (PreToolUse + Bash)
+
+    func testPreToolUseBashPopulatesApprovalFields() {
+        let json = #"{"session_id":"s","cwd":"/proj","hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"npm test"}}"#
+        let event = payload(json)?.makeEvent(now: now)
+        XCTAssertNotNil(event?.approvalRequestId, "must generate a request id for a gated tool")
+        XCTAssertEqual(event?.toolName, "Bash")
+        XCTAssertEqual(event?.toolSummary, "npm test")
+    }
+
+    func testPreToolUseBashTruncatesSummaryTo80Characters() {
+        let longCommand = String(repeating: "a", count: 200)
+        let json = #"{"session_id":"s","cwd":"/proj","hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"\#(longCommand)"}}"#
+        let event = payload(json)?.makeEvent(now: now)
+        XCTAssertEqual(event?.toolSummary?.count, 80, "summary must be truncated to 80 chars")
+    }
+
+    func testPreToolUseBashWithNoCommandFallsBackToToolName() {
+        let json = #"{"session_id":"s","cwd":"/proj","hook_event_name":"PreToolUse","tool_name":"Bash"}"#
+        let event = payload(json)?.makeEvent(now: now)
+        XCTAssertEqual(event?.toolSummary, "Bash", "no command in tool_input -> summary falls back to tool name")
+    }
+
+    func testPreToolUseNonGatedToolLeavesApprovalFieldsNil() {
+        let json = #"{"session_id":"s","cwd":"/proj","hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{"file_path":"/x"}}"#
+        let event = payload(json)?.makeEvent(now: now)
+        XCTAssertNil(event?.approvalRequestId, "Read is not in the gated tool whitelist")
+        XCTAssertNil(event?.toolName)
+        XCTAssertNil(event?.toolSummary)
+    }
+
+    func testNonPreToolUseEventLeavesApprovalFieldsNilEvenForBash() {
+        let json = #"{"session_id":"s","cwd":"/proj","hook_event_name":"Stop","tool_name":"Bash","tool_input":{"command":"npm test"}}"#
+        let event = payload(json)?.makeEvent(now: now)
+        XCTAssertNil(event?.approvalRequestId, "only PreToolUse should ever trigger gating")
+        XCTAssertNil(event?.toolName)
+        XCTAssertNil(event?.toolSummary)
+    }
+
+    func testPreToolUseBashForNonClaudeKindLeavesApprovalFieldsNil() {
+        let json = #"{"session_id":"s","cwd":"/proj","hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"npm test"}}"#
+
+        let codexEvent = payload(json)?.makeEvent(now: now, kind: .codex)
+        XCTAssertNil(codexEvent?.approvalRequestId, "approval gating is a Claude-only contract")
+        XCTAssertNil(codexEvent?.toolName)
+        XCTAssertNil(codexEvent?.toolSummary)
+
+        let droidEvent = payload(json)?.makeEvent(now: now, kind: .droid)
+        XCTAssertNil(droidEvent?.approvalRequestId, "approval gating is a Claude-only contract")
+        XCTAssertNil(droidEvent?.toolName)
+        XCTAssertNil(droidEvent?.toolSummary)
+    }
 }

--- a/Tests/AgentPetCoreTests/ClaudeHookPayloadTests.swift
+++ b/Tests/AgentPetCoreTests/ClaudeHookPayloadTests.swift
@@ -91,7 +91,7 @@ final class ClaudeHookPayloadTests: XCTestCase {
 
     func testPreToolUseBashPopulatesApprovalFields() {
         let json = #"{"session_id":"s","cwd":"/proj","hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"npm test"}}"#
-        let event = payload(json)?.makeEvent(now: now)
+        let event = payload(json)?.makeEvent(now: now, gatedTools: ["Bash"])
         XCTAssertNotNil(event?.approvalRequestId, "must generate a request id for a gated tool")
         XCTAssertEqual(event?.toolName, "Bash")
         XCTAssertEqual(event?.toolSummary, "npm test")
@@ -100,27 +100,35 @@ final class ClaudeHookPayloadTests: XCTestCase {
     func testPreToolUseBashTruncatesSummaryTo80Characters() {
         let longCommand = String(repeating: "a", count: 200)
         let json = #"{"session_id":"s","cwd":"/proj","hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"\#(longCommand)"}}"#
-        let event = payload(json)?.makeEvent(now: now)
+        let event = payload(json)?.makeEvent(now: now, gatedTools: ["Bash"])
         XCTAssertEqual(event?.toolSummary?.count, 80, "summary must be truncated to 80 chars")
     }
 
     func testPreToolUseBashWithNoCommandFallsBackToToolName() {
         let json = #"{"session_id":"s","cwd":"/proj","hook_event_name":"PreToolUse","tool_name":"Bash"}"#
-        let event = payload(json)?.makeEvent(now: now)
+        let event = payload(json)?.makeEvent(now: now, gatedTools: ["Bash"])
         XCTAssertEqual(event?.toolSummary, "Bash", "no command in tool_input -> summary falls back to tool name")
     }
 
     func testPreToolUseNonGatedToolLeavesApprovalFieldsNil() {
         let json = #"{"session_id":"s","cwd":"/proj","hook_event_name":"PreToolUse","tool_name":"Read","tool_input":{"file_path":"/x"}}"#
-        let event = payload(json)?.makeEvent(now: now)
+        let event = payload(json)?.makeEvent(now: now, gatedTools: ["Bash"])
         XCTAssertNil(event?.approvalRequestId, "Read is not in the gated tool whitelist")
+        XCTAssertNil(event?.toolName)
+        XCTAssertNil(event?.toolSummary)
+    }
+
+    func testEmptyGatedToolsDisablesApprovalEvenForBash() {
+        let json = #"{"session_id":"s","cwd":"/proj","hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"npm test"}}"#
+        let event = payload(json)?.makeEvent(now: now, gatedTools: [])
+        XCTAssertNil(event?.approvalRequestId, "empty whitelist means the gate is off")
         XCTAssertNil(event?.toolName)
         XCTAssertNil(event?.toolSummary)
     }
 
     func testNonPreToolUseEventLeavesApprovalFieldsNilEvenForBash() {
         let json = #"{"session_id":"s","cwd":"/proj","hook_event_name":"Stop","tool_name":"Bash","tool_input":{"command":"npm test"}}"#
-        let event = payload(json)?.makeEvent(now: now)
+        let event = payload(json)?.makeEvent(now: now, gatedTools: ["Bash"])
         XCTAssertNil(event?.approvalRequestId, "only PreToolUse should ever trigger gating")
         XCTAssertNil(event?.toolName)
         XCTAssertNil(event?.toolSummary)
@@ -129,14 +137,37 @@ final class ClaudeHookPayloadTests: XCTestCase {
     func testPreToolUseBashForNonClaudeKindLeavesApprovalFieldsNil() {
         let json = #"{"session_id":"s","cwd":"/proj","hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"npm test"}}"#
 
-        let codexEvent = payload(json)?.makeEvent(now: now, kind: .codex)
+        let codexEvent = payload(json)?.makeEvent(now: now, kind: .codex, gatedTools: ["Bash"])
         XCTAssertNil(codexEvent?.approvalRequestId, "approval gating is a Claude-only contract")
         XCTAssertNil(codexEvent?.toolName)
         XCTAssertNil(codexEvent?.toolSummary)
 
-        let droidEvent = payload(json)?.makeEvent(now: now, kind: .droid)
+        let droidEvent = payload(json)?.makeEvent(now: now, kind: .droid, gatedTools: ["Bash"])
         XCTAssertNil(droidEvent?.approvalRequestId, "approval gating is a Claude-only contract")
         XCTAssertNil(droidEvent?.toolName)
         XCTAssertNil(droidEvent?.toolSummary)
+    }
+}
+
+// MARK: - ApprovalGateConfig (opt-in whitelist file)
+
+final class ApprovalGateConfigTests: XCTestCase {
+    func testMissingConfigMeansGateOff() {
+        let missing = NSTemporaryDirectory() + "agentpet-missing-\(UUID().uuidString).json"
+        XCTAssertEqual(ApprovalGateConfig.gatedTools(path: missing), [])
+    }
+
+    func testValidConfigEnablesListedTools() throws {
+        let path = NSTemporaryDirectory() + "agentpet-gate-\(UUID().uuidString).json"
+        try #"{"tools":["Bash","Write"]}"#.write(toFile: path, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        XCTAssertEqual(ApprovalGateConfig.gatedTools(path: path), ["Bash", "Write"])
+    }
+
+    func testMalformedConfigMeansGateOff() throws {
+        let path = NSTemporaryDirectory() + "agentpet-gate-\(UUID().uuidString).json"
+        try "not json".write(toFile: path, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        XCTAssertEqual(ApprovalGateConfig.gatedTools(path: path), [])
     }
 }

--- a/Tests/AgentPetCoreTests/PendingApprovalRegistryTests.swift
+++ b/Tests/AgentPetCoreTests/PendingApprovalRegistryTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import AgentPetCore
+
+final class PendingApprovalRegistryTests: XCTestCase {
+    /// Creates a connected pipe pair, returning (readFD, writeFD). The caller
+    /// owns the read end; `PendingApprovalRegistry` owns/closes the write end.
+    private func makePipe() -> (readFD: Int32, writeFD: Int32) {
+        var fds: [Int32] = [0, 0]
+        fds.withUnsafeMutableBufferPointer { pipe($0.baseAddress) }
+        return (fds[0], fds[1])
+    }
+
+    private func readAll(_ fd: Int32) -> String {
+        let handle = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
+        let data = handle.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+
+    func testResolveWritesDecisionJSONAndClosesFD() {
+        let registry = PendingApprovalRegistry()
+        let (readFD, writeFD) = makePipe()
+        registry.register(requestId: "req-1", fd: writeFD)
+
+        let resolved = registry.resolve(requestId: "req-1", decision: .allow)
+        XCTAssertTrue(resolved)
+
+        let output = readAll(readFD)
+        XCTAssertEqual(output, "{\"decision\":\"allow\"}\n")
+    }
+
+    func testResolveIsIdempotentAndReturnsFalseOnSecondCall() {
+        let registry = PendingApprovalRegistry()
+        let (readFD, writeFD) = makePipe()
+        registry.register(requestId: "req-1", fd: writeFD)
+
+        XCTAssertTrue(registry.resolve(requestId: "req-1", decision: .deny))
+        XCTAssertFalse(registry.resolve(requestId: "req-1", decision: .allow),
+                        "second resolve for the same requestId must be a no-op")
+
+        // Only one write/close should have happened; reading to EOF must not hang or crash.
+        _ = readAll(readFD)
+    }
+
+    func testResolveUnknownRequestIdReturnsFalse() {
+        let registry = PendingApprovalRegistry()
+        XCTAssertFalse(registry.resolve(requestId: "never-registered", decision: .ask))
+    }
+
+    func testUnresolvedRequestAutoResolvesToAskAfterTimeout() {
+        let registry = PendingApprovalRegistry()
+        let (readFD, writeFD) = makePipe()
+        let expectation = expectation(description: "timeout auto-resolve")
+
+        registry.register(requestId: "req-timeout", fd: writeFD, timeout: 0.2)
+
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2)
+
+        let output = readAll(readFD)
+        XCTAssertEqual(output, "{\"decision\":\"ask\"}\n", "no manual resolve before timeout -> auto .ask")
+    }
+
+    func testManualResolveBeforeTimeoutPreventsAutoAskOverwrite() {
+        let registry = PendingApprovalRegistry()
+        let (readFD, writeFD) = makePipe()
+
+        registry.register(requestId: "req-early", fd: writeFD, timeout: 0.2)
+        XCTAssertTrue(registry.resolve(requestId: "req-early", decision: .allow))
+
+        // Wait past the timeout window; the auto-timeout must not fire again
+        // (fd is already closed) and must not crash.
+        let expectation = expectation(description: "wait past timeout window")
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2)
+
+        let output = readAll(readFD)
+        XCTAssertEqual(output, "{\"decision\":\"allow\"}\n")
+    }
+}

--- a/Tests/AgentPetCoreTests/PendingApprovalRegistryTests.swift
+++ b/Tests/AgentPetCoreTests/PendingApprovalRegistryTests.swift
@@ -80,4 +80,18 @@ final class PendingApprovalRegistryTests: XCTestCase {
         let output = readAll(readFD)
         XCTAssertEqual(output, "{\"decision\":\"allow\"}\n")
     }
+
+    func testResolveAfterPeerClosedDoesNotCrash() {
+        let registry = PendingApprovalRegistry()
+        var fds: [Int32] = [0, 0]
+        fds.withUnsafeMutableBufferPointer { _ = socketpair(AF_UNIX, SOCK_STREAM, 0, $0.baseAddress) }
+
+        registry.register(requestId: "req-gone", fd: fds[1])
+        close(fds[0])   // peer (the CLI side) goes away before the decision
+
+        // Without SO_NOSIGPIPE this write raises SIGPIPE and kills the process.
+        XCTAssertTrue(registry.resolve(requestId: "req-gone", decision: .ask),
+                      "resolve still consumes the registration even when the write fails")
+        XCTAssertFalse(registry.resolve(requestId: "req-gone", decision: .ask))
+    }
 }

--- a/Tests/AgentPetCoreTests/SessionStoreTests.swift
+++ b/Tests/AgentPetCoreTests/SessionStoreTests.swift
@@ -199,4 +199,67 @@ final class SessionStoreTests: XCTestCase {
         let order = store.sorted.map(\.id)
         XCTAssertEqual(order, ["working", "waiting", "done"])
     }
+
+    // MARK: - pendingApproval gating
+
+    private func approvalEvent(
+        requestId: String? = "req-1", toolName: String? = "Bash", toolSummary: String? = "npm test",
+        session: String = "s1", at date: Date
+    ) -> AgentEvent {
+        AgentEvent(
+            sessionId: session, agentKind: .claude, eventName: "PreToolUse", project: "/proj",
+            approvalRequestId: requestId, toolName: toolName, toolSummary: toolSummary, timestamp: date
+        )
+    }
+
+    func testApplyWithApprovalRequestIdSetsWaitingStateAndPendingApproval() {
+        let store = SessionStore()
+        let s = store.apply(approvalEvent(at: t0), now: t0)
+        XCTAssertEqual(s?.state, .waiting, "a gated tool request must override the PreToolUse .working mapping")
+        XCTAssertEqual(s?.pendingApproval?.requestId, "req-1")
+        XCTAssertEqual(s?.pendingApproval?.toolName, "Bash")
+        XCTAssertEqual(s?.pendingApproval?.summary, "npm test")
+    }
+
+    func testSubsequentEventWithoutApprovalIdClearsPendingApproval() {
+        let store = SessionStore()
+        store.apply(approvalEvent(at: t0), now: t0)
+        let updated = store.apply(event("PostToolUse"), now: t0.addingTimeInterval(1))
+        XCTAssertNil(updated?.pendingApproval, "a later event with no approval request must clear a stale one")
+    }
+
+    func testSecondApprovalRequestOverwritesPendingApprovalNewestWins() {
+        let store = SessionStore()
+        store.apply(approvalEvent(requestId: "req-1", at: t0), now: t0)
+        let second = store.apply(
+            approvalEvent(requestId: "req-2", toolName: "Bash", toolSummary: "rm -rf tmp", at: t0.addingTimeInterval(1)),
+            now: t0.addingTimeInterval(1)
+        )
+        XCTAssertEqual(second?.pendingApproval?.requestId, "req-2", "newest pending approval wins, it does not queue")
+        XCTAssertEqual(second?.pendingApproval?.summary, "rm -rf tmp")
+    }
+
+    func testResolveApprovalClearsPendingApprovalAndSetsWorkingWhenIdMatches() {
+        let store = SessionStore()
+        store.apply(approvalEvent(requestId: "req-1", at: t0), now: t0)
+        let resolved = store.resolveApproval(id: "s1", requestId: "req-1")
+        XCTAssertTrue(resolved)
+        XCTAssertNil(store.session(id: "s1")?.pendingApproval)
+        XCTAssertEqual(store.session(id: "s1")?.state, .working)
+    }
+
+    func testResolveApprovalNoOpsWhenRequestIdMismatches() {
+        let store = SessionStore()
+        store.apply(approvalEvent(requestId: "req-1", at: t0), now: t0)
+        let resolved = store.resolveApproval(id: "s1", requestId: "wrong-id")
+        XCTAssertFalse(resolved)
+        XCTAssertEqual(store.session(id: "s1")?.pendingApproval?.requestId, "req-1",
+                       "mismatched requestId must not clear an unrelated/newer pending approval")
+        XCTAssertEqual(store.session(id: "s1")?.state, .waiting)
+    }
+
+    func testResolveApprovalNoOpsWhenSessionMissing() {
+        let store = SessionStore()
+        XCTAssertFalse(store.resolveApproval(id: "missing", requestId: "req-1"))
+    }
 }


### PR DESCRIPTION
## What

Lets the user answer a Claude Code `PreToolUse` permission request for gated tools (currently `Bash`) directly from the pet's speech bubble, instead of switching back to the terminal. The bubble shows a pending-approval row (orange dot + `Bash: <command>` + **Allow** / **Deny** buttons); the decision is written back to the hook, which prints the `hookSpecificOutput.permissionDecision` JSON that Claude Code consumes.

**The feature is opt-in and OFF by default** — nothing changes for existing users unless they create `~/.agentpet/approval-gate.json` with e.g. `{"tools":["Bash"]}`.

## How

- `agentpet hook`: a `PreToolUse` event whose tool is on the opt-in whitelist gets an `approvalRequestId` and is sent via a new `EventSender.sendAndAwaitReply` — connect, write, then block reading the reply (12s cap via `SO_RCVTIMEO` + a total deadline). All failure paths (no daemon, timeout, decode error) fall back to `"ask"`, i.e. Claude Code's normal interactive prompt — the gate can never silently allow or deny.
- Daemon: `EventSocketServer.handleClient` hands an approval connection's fd to a new `PendingApprovalRegistry` (serial-queue guarded) instead of closing it; the accept loop is never blocked. The registry auto-resolves to `"ask"` after 10s — deliberately shorter than the client's 12s so the reply always lands on a live fd.
- UI: `AgentRow` renders a `PendingApprovalRow` when the session has a pending approval; buttons call `AppDaemon.resolveApproval`, which writes the decision to the fd and optimistically clears the pending state (requestId-guarded so a stale click can't clobber a newer request).
- Robustness: the daemon ignores `SIGPIPE` and both sides set `SO_NOSIGPIPE` — a reply racing a vanished peer returns `EPIPE` instead of killing the app (found via live testing; covered by a regression test).

## Scope / non-goals

- Claude Code only (`kind == .claude` is enforced; Codex/Droid events routed through the same payload decoder are unaffected — covered by tests).
- Whitelist is a config file for now; a Settings UI can follow.
- Known limitation (documented in code): a timeout resolves the CLI side but the bubble row clears on the session's next event.

## Verification

- 341 tests pass (unit + real-unix-socket integration: allow/deny/timeout/no-daemon round trips, registry idempotency/timeout, SIGPIPE regression, opt-in config).
- Live end-to-end on macOS: clicking **Allow** in the bubble delivered `permissionDecision=allow` to the hook in ~9s; an unanswered request fell back to `"ask"` at 10s with the daemon surviving; with the config absent, hooks behave exactly as before (fire-and-forget, no added latency).