### PR TITLE
feat: Settings toggle for the Bash approval gate

### DIFF
--- a/Sources/AgentPetCore/ApprovalGateConfig.swift
+++ b/Sources/AgentPetCore/ApprovalGateConfig.swift
@@ -16,7 +16,26 @@ public enum ApprovalGateConfig {
         return Set(config.tools)
     }
 
-    private struct Config: Decodable {
+    /// Whether `tool` is currently gated.
+    public static func isEnabled(tool: String = "Bash", path: String? = nil) -> Bool {
+        gatedTools(path: path).contains(tool)
+    }
+
+    /// Turns the gate for `tool` on (writes the config file) or off (removes
+    /// it). Mirrors the opt-in default: no file on disk means disabled.
+    public static func setEnabled(_ enabled: Bool, tool: String = "Bash", path: String? = nil) {
+        let file = path ?? defaultPath
+        guard enabled else {
+            try? FileManager.default.removeItem(atPath: file)
+            return
+        }
+        let dir = (file as NSString).deletingLastPathComponent
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        guard let data = try? JSONEncoder().encode(Config(tools: [tool])) else { return }
+        try? data.write(to: URL(fileURLWithPath: file))
+    }
+
+    private struct Config: Codable {
         let tools: [String]
     }
 }

--- a/Sources/App/SettingsModel.swift
+++ b/Sources/App/SettingsModel.swift
@@ -28,10 +28,16 @@ final class SettingsModel: ObservableObject {
         didSet { UserDefaults.standard.set(notificationsEnabled, forKey: NotificationManager.enabledKey) }
     }
 
+    /// Backed by `~/.agentpet/approval-gate.json` so the separate hook CLI process reads it too.
+    @Published var approvalGateEnabled: Bool {
+        didSet { ApprovalGateConfig.setEnabled(approvalGateEnabled) }
+    }
+
     let agents = AgentCatalog.all
 
     init() {
         notificationsEnabled = (UserDefaults.standard.object(forKey: NotificationManager.enabledKey) as? Bool) ?? true
+        approvalGateEnabled = ApprovalGateConfig.isEnabled()
     }
 
     func refresh() {

--- a/Sources/App/SetupView.swift
+++ b/Sources/App/SetupView.swift
@@ -390,6 +390,18 @@ private struct GeneralTab: View {
                 }
             }
 
+            Section("Bash approval gate") {
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Approve Bash from the bubble")
+                        Text("Claude Code Bash requests show Allow/Deny in the bubble instead of the terminal.")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    ColorSwitch(isOn: $model.approvalGateEnabled)
+                }
+            }
+
             Section("About") {
                 LabeledContent("Version", value: appVersion)
             }

--- a/Tests/AgentPetCoreTests/ClaudeHookPayloadTests.swift
+++ b/Tests/AgentPetCoreTests/ClaudeHookPayloadTests.swift
@@ -170,4 +170,21 @@ final class ApprovalGateConfigTests: XCTestCase {
         defer { try? FileManager.default.removeItem(atPath: path) }
         XCTAssertEqual(ApprovalGateConfig.gatedTools(path: path), [])
     }
+
+    func testSetEnabledWritesFileAndIsEnabledReadsIt() {
+        let path = NSTemporaryDirectory() + "agentpet-gate-\(UUID().uuidString).json"
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        ApprovalGateConfig.setEnabled(true, path: path)
+        XCTAssertTrue(ApprovalGateConfig.isEnabled(path: path))
+        XCTAssertEqual(ApprovalGateConfig.gatedTools(path: path), ["Bash"])
+    }
+
+    func testSetEnabledFalseRemovesFile() {
+        let path = NSTemporaryDirectory() + "agentpet-gate-\(UUID().uuidString).json"
+        ApprovalGateConfig.setEnabled(true, path: path)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: path))
+        ApprovalGateConfig.setEnabled(false, path: path)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: path))
+        XCTAssertFalse(ApprovalGateConfig.isEnabled(path: path))
+    }
 }


### PR DESCRIPTION
## What

Follows up on #45 ("Known limitation" section noted a Settings UI could follow). Adds a switch under **Settings > General > Bash approval gate** so users no longer need to hand-create `~/.agentpet/approval-gate.json` to opt in.

## How

- `ApprovalGateConfig.setEnabled(_:tool:path:)` / `.isEnabled(tool:path:)`: writes `{"tools":["Bash"]}` to the config file (or removes it), mirroring the existing opt-in-via-file contract read by `gatedTools`.
- `SettingsModel.approvalGateEnabled`: reads the current state on init, writes through `ApprovalGateConfig.setEnabled` on change. Backed by the JSON file (not `UserDefaults`), since the hook CLI is a separate process that reads the same file.
- `SetupView` (General tab): new "Bash approval gate" section with a `ColorSwitch`, next to the existing "Agent integrations" hook-install controls.

## Scope

- Only the Bash tool toggle, matching the current whitelist scope from #45. No changes to the daemon/hook/bubble approval flow itself.

## Verification

- New tests in `ClaudeHookPayloadTests.swift` (`ApprovalGateConfigTests`): write/read round trip and disable-removes-file, alongside the existing missing/valid/malformed-config cases. `swift test --filter ApprovalGateConfigTests` — 5/5 pass.
- `swift build` succeeds for the app target (SwiftUI toggle wiring compiles).