### PR TITLE
fix(care): stop streak loss when syncing across devices

### DIFF
--- a/Sources/AgentPetCore/PetCare.swift
+++ b/Sources/AgentPetCore/PetCare.swift
@@ -316,6 +316,9 @@ public enum PetCare {
             if s.lastFedAt == nil || cloudFed > s.lastFedAt! {
                 s.lastFedAt = cloudFed
                 s.streakDays = cloud.streak
+                // Keep the day bookkeeping in sync with the adopted feeding, or the
+                // next local feed sees a stale key and resets the streak to 1.
+                s.lastFedDayKey = dayKey(for: cloudFed)
             }
         }
         if !cloud.achievements.isEmpty {

--- a/Tests/AgentPetCoreTests/RestoreMergeTests.swift
+++ b/Tests/AgentPetCoreTests/RestoreMergeTests.swift
@@ -66,6 +66,16 @@ final class RestoreMergeTests: XCTestCase {
         XCTAssertEqual(merged.lastFedAt, local.lastFedAt)
     }
 
+    // After adopting the cloud's more-recent feeding, lastFedDayKey must track it
+    // too, or the next local feed would reset the streak to 1 (issue: streak lost
+    // after multi-device sync).
+    func testAdoptingCloudFeedingSetsDayKey() {
+        let cloudFed = Date(timeIntervalSince1970: 1_782_690_000)
+        let merged = PetCare.merging(nil, with: cloud(streak: 5, lastFedAt: cloudFed), now: now)
+        XCTAssertEqual(merged.lastFedDayKey, PetCare.dayKey(for: cloudFed))
+        XCTAssertEqual(merged.streakDays, 5)
+    }
+
     // Achievements union across machines.
     func testAchievementsUnion() {
         var local = PetCareState()

--- a/web/src/pages/api/care/sync.ts
+++ b/web/src/pages/api/care/sync.ts
@@ -6,8 +6,11 @@ export const prerender = false;
 export { OPTIONS };
 
 // The desktop app pushes per-pet care stats with its device token. Upserts:
-// stats only ever move forward (MAX) so an out-of-date device can't shrink a
-// pet that levelled up elsewhere.
+// lifetime counters (xp/tokens/meals) only ever move forward (MAX) so an
+// out-of-date device can't shrink a pet that levelled up elsewhere. Streak
+// isn't monotonic (it resets on missed days), so streak + last_fed_at follow
+// the most recent feeding rather than the last write — mirroring the client
+// merge in PetCare.merging — so a stale device can't clobber a fresher streak.
 export const POST: APIRoute = async ({ request }) => {
   const auth = request.headers.get("authorization") || "";
   const token = auth.startsWith("Bearer ") ? auth.slice(7).trim() : "";
@@ -61,8 +64,14 @@ export const POST: APIRoute = async ({ request }) => {
              xp=MAX(care_pets.xp, excluded.xp),
              tokens=MAX(care_pets.tokens, excluded.tokens),
              meals=MAX(care_pets.meals, excluded.meals),
-             streak=excluded.streak,
-             last_fed_at=excluded.last_fed_at,
+             streak=CASE
+               WHEN excluded.last_fed_at IS NOT NULL
+                 AND (care_pets.last_fed_at IS NULL OR excluded.last_fed_at > care_pets.last_fed_at)
+               THEN excluded.streak ELSE care_pets.streak END,
+             last_fed_at=CASE
+               WHEN excluded.last_fed_at IS NOT NULL
+                 AND (care_pets.last_fed_at IS NULL OR excluded.last_fed_at > care_pets.last_fed_at)
+               THEN excluded.last_fed_at ELSE care_pets.last_fed_at END,
              updated_at=excluded.updated_at,
              thumb=COALESCE(excluded.thumb, care_pets.thumb),
              week=COALESCE(excluded.week, care_pets.week),

--- a/windows/src/sync.ts
+++ b/windows/src/sync.ts
@@ -114,6 +114,9 @@ export async function restore(): Promise<number> {
         if (s.lastFedAt == null || cloudFed > s.lastFedAt) {
           s.lastFedAt = cloudFed;
           s.streakDays = c.streak || 0;
+          // Keep the day bookkeeping in sync with the adopted feeding, or the
+          // next local feed sees a stale key and resets the streak to 1.
+          s.lastFedDayKey = care.dayKey(new Date(cloudFed));
         }
       }
       // Achievements union, then reconcile against the merged (higher) stats.


### PR DESCRIPTION
## Summary

Fixes cross-device care sync wiping a pet's **streak**. Two independent bugs combined to cause the loss:

- **Server (`web/src/pages/api/care/sync.ts`)** overwrote `streak` and `last_fed_at` unconditionally on every push. Lifetime counters (`xp`/`tokens`/`meals`) use `MAX`, but streak isn't monotonic — so a stale device (fed on an earlier day) that synced last would clobber a fresher streak stored from another machine. Now both columns are guarded with a `CASE` so they only advance when the incoming `last_fed_at` is newer, mirroring `PetCare.merging`.
- **Client merge** (`PetCare.merging` on macOS, `restore()` on Windows) adopted the cloud's more-recent `lastFedAt` and `streak` but never updated `lastFedDayKey`. The next local feeding then saw a stale day key and reset the streak to `1`. Now `lastFedDayKey` is set from the adopted feeding.

## Changes

- `web/src/pages/api/care/sync.ts` — conditional `streak` / `last_fed_at` upsert (most-recent-feeding wins).
- `Sources/AgentPetCore/PetCare.swift` — set `lastFedDayKey` when adopting cloud feeding in `merging`.
- `windows/src/sync.ts` — same `lastFedDayKey` fix in `restore()` (parity).
- `Tests/AgentPetCoreTests/RestoreMergeTests.swift` — regression test `testAdoptingCloudFeedingSetsDayKey`.

## Test plan

- [x] `swift test` — 374 passed (incl. new regression test)
- [x] `tsc --noEmit` (windows) — passes
- [x] `astro build` (web) — builds
- [x] `cargo test` (windows/src-tauri) — 11 passed

## Notes

- Streak data already overwritten in the cloud won't self-heal; this prevents further loss going forward.
- No `package-lock.json` changes are included in this PR.

Made with [Cursor](https://cursor.com)